### PR TITLE
fix: use shiki/bundle/full to resolve edge runtime URL error

### DIFF
--- a/packages/frontend/src/features/markdown/compile_mdx.ts
+++ b/packages/frontend/src/features/markdown/compile_mdx.ts
@@ -7,6 +7,7 @@ import remark_comment from "remark-comment";
 import remark_gemoji from "remark-gemoji";
 import remark_gfm from "remark-gfm";
 import remark_math from "remark-math";
+import { getSingletonHighlighter } from "shiki/bundle/full";
 import { create_custom_components } from "./custom_components";
 import {
   linkcard_handler,
@@ -48,6 +49,7 @@ export async function compile_mdx({
             {
               theme: moonlight_ii_theme,
               keepBackground: false,
+              getHighlighter: getSingletonHighlighter,
             },
           ],
           rehype_katex,


### PR DESCRIPTION
## Summary

- `rehype-pretty-code` のデフォルトである `shiki` の `getSingletonHighlighter` が、言語グラマーファイルを相対URL（`languages/abap.tmLanguage.json` など）で動的ロードしようとするため、Cloudflare Workers（edge runtime）でベースURLが存在せずエラーになっていた
- `shiki/bundle/full` の `getSingletonHighlighter` を `getHighlighter` オプションとして渡すことで修正。こちらはグラマーをJSオブジェクトとして静的にバンドルしているため、ファイルシステムアクセス不要

## Test plan

- [ ] ブログ記事ページを開いてコードブロックがシンタックスハイライトされて表示されることを確認
- [ ] `next dev` (wrangler dev) でInternal Server Errorが出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)