### PR TITLE
fix(deploy): run gen before the standalone frontend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy:secret": "dotenvx run -- pnpm -r --workspace-concurrency=1 run deploy:secret",
     "staging": "pnpm run build && dotenvx run -- pnpm -r --workspace-concurrency=1 run staging",
     "staging:secret": "dotenvx run -- pnpm -r --workspace-concurrency=1 run staging:secret",
-    "build:frontend": "dotenvx run -- pnpm run --filter=frontend build:prod",
+    "build:frontend": "pnpm -r run gen && dotenvx run -- pnpm run --filter=frontend build:prod",
     "deploy:frontend": "dotenvx run -- pnpm run --filter=frontend deploy:prod"
   },
   "devDependencies": {


### PR DESCRIPTION
PR #39 マージ後のデプロイ失敗(run 30920029527)の修正。

## 原因

deploy.yaml の「Deploy frontend」ステップは `build:frontend` → `opennextjs-cloudflare build` を直接実行するが、`src/styled-system`(panda codegen の生成物、gitignored)が存在せず `Module not found: Can't resolve '@/styled-system/css'` で失敗した。

turbo 撤去前は、直前の backend デプロイステップの `turbo run deploy` がタスクグラフの副作用で frontend の gen(panda codegen / nitrogql / schema 生成)を実行しており、`build:frontend` はその生成物に暗黙に依存していた(旧成功 run 30873790641 のログで確認)。#39 で deploy を backend 直指定にしたことで、この暗黙の前段が消えた。

## 修正

`build:frontend` を他の root スクリプト(build / typecheck / dev)と同じく gen 込みの自己完結型に変更:

```
"build:frontend": "pnpm -r run gen && dotenvx run -- pnpm run --filter=frontend build:prod"
```

## 検証

ローカルで `src/styled-system` を削除して CI と同じ初期状態を再現 → 修正前の失敗を確認 → 修正後は gen が走り OpenNext ビルドまで成功。

## 現在の本番状態

- backend: #39 反映済みで正常(認証 401 確認)
- frontend: 旧ビルドのまま配信中だが、#39 に frontend の実行時変更はないため実害なし(トップ・記事ページ 200 確認)
- 本 PR のマージで frontend も追いつく

🤖 Generated with [Claude Code](https://claude.com/claude-code)
