### PR TITLE
ci: pin actions to commit SHAs and minimize permissions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,15 +5,15 @@ runs:
   using: composite
   steps:
     - name: Setup Nix
-      uses: DeterminateSystems/nix-installer-action@main
+      uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
     - name: Setup Nix binary cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
+      uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
     - name: Get pnpm store directory
       id: pnpm-cache
       shell: bash
       run: echo "STORE_PATH=$(nix develop .#ci --command pnpm store path --silent)" >> "$GITHUB_OUTPUT"
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,15 +8,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint
@@ -27,11 +27,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Typecheck
@@ -40,11 +37,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build

--- a/.github/workflows/deploy-secret.yaml
+++ b/.github/workflows/deploy-secret.yaml
@@ -10,16 +10,16 @@ on:
 env:
   DOTENV_PRIVATE_KEY_PRODUCTION: ${{secrets.DOTENV_PRIVATE_KEY_PRODUCTION}}
 
+permissions:
+  contents: read
+
 jobs:
   deploy-secret:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Typecheck
+      - name: Deploy secrets
         run: nix develop .#ci --command pnpm run deploy:secret

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,15 +11,15 @@ on:
 env:
   DOTENV_PRIVATE_KEY_PRODUCTION: ${{secrets.DOTENV_PRIVATE_KEY_PRODUCTION}}
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Deploy

--- a/.github/workflows/migrate.yaml
+++ b/.github/workflows/migrate.yaml
@@ -11,15 +11,15 @@ on:
 env:
   DOTENV_PRIVATE_KEY_PRODUCTION: ${{secrets.DOTENV_PRIVATE_KEY_PRODUCTION}}
 
+permissions:
+  contents: read
+
 jobs:
   migrate:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Migrate


### PR DESCRIPTION
## 概要

GitHub Actions の `uses:` 参照を全て full commit SHA に固定し、ワークフローの `permissions` を最小権限に絞りました。あわせて `deploy-secret.yaml` の誤ったステップ名を修正しています。

Closes #25

## 1. アクション参照の SHA 固定

`@main` / `@v4` といった浮動参照を廃止し、実在する commit SHA を `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` で確認した上で固定しました。

| アクション | 変更前 | 変更後 (SHA) | バージョン |
| --- | --- | --- | --- |
| `DeterminateSystems/nix-installer-action` | `@main` | `ef8a148080ab6020fd15196c2084a2eea5ff2d25` | v22 |
| `DeterminateSystems/magic-nix-cache-action` | `@main` | `908b263ff629f4cc17666315b7fd3ec127c6244d` | v14 |
| `actions/cache` | `@v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |

- `@main` だった 2 つは、それぞれの最新安定リリース (v22 / v14) の SHA を採用しました。
- `actions/*` は v4 系の最新パッチに固定しています。メジャーバージョンの引き上げ (checkout v7 / cache v6) は挙動変更を伴うため本 PR のスコープ外としました。
- 4 つの SHA すべてについて、その ref に `action.yml` が存在することを API で確認済みです。
- 対象ファイルは `.github/actions/setup/action.yaml` (composite action) と各ワークフローです。

## 2. permissions の最小化

全ワークフローでジョブごとの `permissions` ブロックを廃し、トップレベルに `permissions: contents: read` を置く形へ統一しました。

| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| `ci.yaml` (lint / typecheck / build) | job ごとに `contents: read` + `deployments: write` | top-level `contents: read` のみ |
| `deploy.yaml` | `contents: read` + `deployments: write` | top-level `contents: read` のみ |
| `deploy-secret.yaml` | `contents: read` + `deployments: write` | top-level `contents: read` のみ |
| `migrate.yaml` | `contents: read` + `deployments: write` | top-level `contents: read` のみ |

`deployments: write` は deploy 系も含めて全て削除しています。デプロイ・マイグレーションはいずれも wrangler / dotenvx 経由で Cloudflare API トークンを使っており、GitHub の Deployments API も `GITHUB_TOKEN` も一切参照していないことをリポジトリ全体の grep で確認しました。

## 3. ステップ名の修正

`deploy-secret.yaml` のステップ名が実態と食い違っていたため修正しました (`Typecheck` → `Deploy secrets`)。実行コマンドは変更していません。

## 検証

- `actionlint` 1.7.9 を全ワークフローに対して実行し、警告ゼロを確認しました。
- ジョブ構成・実行コマンドの変更は行っていません (ステップ名の文字列を除く)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
