### PR TITLE
test: introduce vitest with sync CLI unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,16 @@ jobs:
       - name: Typecheck
         run: nix develop .#ci --command pnpm run typecheck
 
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Test
+        run: nix develop .#ci --command pnpm run test
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "typecheck": "pnpm -r run gen && pnpm -r run typecheck",
+    "test": "pnpm -r run test",
     "dev": "pnpm -r run gen && dotenvx run -- pnpm -r --parallel run dev",
     "build": "pnpm -r run gen && dotenvx run -- pnpm -r run build",
     "start": "dotenvx run -- pnpm -r --parallel run start",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc",
+    "test": "vitest run",
     "sync": "tsx src/main.ts sync"
   },
   "dependencies": {
@@ -14,6 +15,7 @@
     "@asa1984.dev/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/cli/src/content.test.ts
+++ b/packages/cli/src/content.test.ts
@@ -1,0 +1,155 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadBlogs, loadContexts } from "./content";
+
+let contentDir: string;
+
+beforeEach(() => {
+  contentDir = mkdtempSync(join(tmpdir(), "cli-content-"));
+});
+
+afterEach(() => {
+  rmSync(contentDir, { recursive: true, force: true });
+});
+
+/** Writes `files` (relative paths) under `content/<kind>/<slug>/`. */
+function writePost(
+  kind: "blog" | "context",
+  slug: string,
+  source: string,
+  files: string[] = [],
+): string {
+  const dir = join(contentDir, kind, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "post.md"), source);
+  for (const file of files) writeFileSync(join(dir, file), file);
+  return dir;
+}
+
+const blogSource = (overrides: Partial<Record<string, string>> = {}) =>
+  [
+    "---",
+    `title: ${overrides.title ?? "Hello"}`,
+    `image: ${overrides.image ?? "cover.png"}`,
+    `description: ${overrides.description ?? "A post"}`,
+    `published: ${overrides.published ?? "true"}`,
+    "---",
+    "# Body",
+  ].join("\n");
+
+const contextSource = (overrides: Partial<Record<string, string>> = {}) =>
+  [
+    "---",
+    `title: ${overrides.title ?? "Nix"}`,
+    `emoji: ${overrides.emoji ?? "❄️"}`,
+    `published: ${overrides.published ?? "true"}`,
+    "---",
+    "# Body",
+  ].join("\n");
+
+describe("loadBlogs", () => {
+  it("loads a blog directory into a LocalBlog", () => {
+    const dir = writePost("blog", "hello", blogSource(), ["cover.png"]);
+    expect(loadBlogs(contentDir)).toEqual([
+      {
+        slug: "hello",
+        title: "Hello",
+        image: "cover.png",
+        description: "A post",
+        published: true,
+        content: "# Body",
+        images: ["cover.png"],
+        dir,
+      },
+    ]);
+  });
+
+  it("does not treat post.md as an image", () => {
+    writePost("blog", "hello", blogSource(), ["cover.png"]);
+    const [blog] = loadBlogs(contentDir);
+    expect(blog?.images).toEqual(["cover.png"]);
+    expect(blog?.images).not.toContain("post.md");
+  });
+
+  it("sorts slugs and image file names", () => {
+    writePost("blog", "b-post", blogSource(), ["cover.png", "a.png", "z.png"]);
+    writePost("blog", "a-post", blogSource(), ["cover.png"]);
+    expect(loadBlogs(contentDir).map((blog) => blog.slug)).toEqual([
+      "a-post",
+      "b-post",
+    ]);
+    expect(loadBlogs(contentDir)[1]?.images).toEqual([
+      "a.png",
+      "cover.png",
+      "z.png",
+    ]);
+  });
+
+  it("keeps unpublished posts (the backend filters on read)", () => {
+    writePost("blog", "draft", blogSource({ published: "false" }), [
+      "cover.png",
+    ]);
+    expect(loadBlogs(contentDir)[0]?.published).toBe(false);
+  });
+
+  it("throws when the frontmatter image is not in the directory", () => {
+    writePost("blog", "hello", blogSource({ image: "missing.png" }), [
+      "cover.png",
+    ]);
+    expect(() => loadBlogs(contentDir)).toThrow(
+      'blog/hello: image "missing.png" does not exist',
+    );
+  });
+
+  it("reports the offending file when the frontmatter is invalid", () => {
+    writePost("blog", "hello", "no frontmatter here", ["cover.png"]);
+    expect(() => loadBlogs(contentDir)).toThrow("blog/hello/post.md");
+  });
+
+  it("returns an empty array when there is no blog directory", () => {
+    expect(loadBlogs(contentDir)).toEqual([]);
+  });
+});
+
+describe("loadContexts", () => {
+  it("loads a context directory into a LocalContext", () => {
+    const dir = writePost("context", "nix", contextSource(), ["setup.webp"]);
+    expect(loadContexts(contentDir)).toEqual([
+      {
+        slug: "nix",
+        title: "Nix",
+        emoji: "❄️",
+        published: true,
+        content: "# Body",
+        images: ["setup.webp"],
+        dir,
+      },
+    ]);
+  });
+
+  it("does not require the images to be referenced by the frontmatter", () => {
+    writePost("context", "nix", contextSource(), []);
+    expect(loadContexts(contentDir)[0]?.images).toEqual([]);
+  });
+
+  it("does not treat post.md as an image", () => {
+    writePost("context", "nix", contextSource(), ["setup.webp"]);
+    expect(loadContexts(contentDir)[0]?.images).toEqual(["setup.webp"]);
+  });
+
+  it("reports the offending file when the frontmatter is invalid", () => {
+    writePost("context", "nix", contextSource({ emoji: '""' }));
+    expect(() => loadContexts(contentDir)).toThrow("context/nix/post.md");
+  });
+
+  it("returns an empty array when there is no context directory", () => {
+    expect(loadContexts(contentDir)).toEqual([]);
+  });
+
+  it("ignores the blog directory", () => {
+    writePost("blog", "hello", blogSource(), ["cover.png"]);
+    expect(loadContexts(contentDir)).toEqual([]);
+  });
+});

--- a/packages/cli/src/frontmatter.test.ts
+++ b/packages/cli/src/frontmatter.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseBlogPost,
+  parseContextPost,
+  splitFrontmatter,
+} from "./frontmatter";
+
+describe("splitFrontmatter", () => {
+  it("splits the header and the body", () => {
+    const source = [
+      "---",
+      "title: Hello",
+      "published: true",
+      "---",
+      "# Body",
+      "",
+      "text",
+    ].join("\n");
+    expect(splitFrontmatter(source)).toEqual({
+      header: "title: Hello\npublished: true",
+      body: "# Body\n\ntext",
+    });
+  });
+
+  it("returns an empty body when nothing follows the header", () => {
+    expect(splitFrontmatter("---\ntitle: Hello\n---")).toEqual({
+      header: "title: Hello",
+      body: "",
+    });
+  });
+
+  it("keeps a body line that itself is a horizontal rule", () => {
+    const source = ["---", "title: Hello", "---", "intro", "---", "outro"].join(
+      "\n",
+    );
+    expect(splitFrontmatter(source)).toEqual({
+      header: "title: Hello",
+      body: "intro\n---\noutro",
+    });
+  });
+
+  it('throws when the beginning "---" is missing', () => {
+    expect(() => splitFrontmatter("title: Hello\n---\nbody")).toThrow(
+      'Missing beginning "---"',
+    );
+  });
+
+  it('throws when the ending "---" is missing', () => {
+    expect(() => splitFrontmatter("---\ntitle: Hello\nbody")).toThrow(
+      'Missing ending "---"',
+    );
+  });
+
+  it("normalizes CRLF line endings", () => {
+    const source = "---\r\ntitle: Hello\r\n---\r\n# Body\r\ntext";
+    expect(splitFrontmatter(source)).toEqual({
+      header: "title: Hello",
+      body: "# Body\ntext",
+    });
+  });
+});
+
+const blogSource = (header: string) => `---\n${header}\n---\n# Body`;
+
+describe("parseBlogPost", () => {
+  it("parses the frontmatter and the content", () => {
+    const source = blogSource(
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+      ].join("\n"),
+    );
+    expect(parseBlogPost(source)).toEqual({
+      frontmatter: {
+        title: "Hello",
+        image: "cover.png",
+        description: "A post",
+        published: true,
+      },
+      content: "# Body",
+    });
+  });
+
+  it.each([
+    [
+      "title is an empty string",
+      [
+        'title: ""',
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+      ],
+    ],
+    [
+      "image is an empty string",
+      ["title: Hello", 'image: ""', "description: A post", "published: true"],
+    ],
+    [
+      "description is an empty string",
+      [
+        "title: Hello",
+        "image: cover.png",
+        'description: ""',
+        "published: true",
+      ],
+    ],
+    [
+      "image is missing",
+      ["title: Hello", "description: A post", "published: true"],
+    ],
+    [
+      "published is missing",
+      ["title: Hello", "image: cover.png", "description: A post"],
+    ],
+    [
+      "published is not a boolean",
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        'published: "yes"',
+      ],
+    ],
+  ])("rejects the frontmatter when %s", (_name, header) => {
+    expect(() => parseBlogPost(blogSource(header.join("\n")))).toThrow();
+  });
+});
+
+describe("parseContextPost", () => {
+  it("parses the frontmatter and the content", () => {
+    const source = blogSource(
+      ["title: Hello", "emoji: 🐧", "published: false"].join("\n"),
+    );
+    expect(parseContextPost(source)).toEqual({
+      frontmatter: { title: "Hello", emoji: "🐧", published: false },
+      content: "# Body",
+    });
+  });
+
+  it.each([
+    ["title is an empty string", ['title: ""', "emoji: 🐧", "published: true"]],
+    [
+      "emoji is an empty string",
+      ["title: Hello", 'emoji: ""', "published: true"],
+    ],
+    ["emoji is missing", ["title: Hello", "published: true"]],
+    ["published is missing", ["title: Hello", "emoji: 🐧"]],
+  ])("rejects the frontmatter when %s", (_name, header) => {
+    expect(() => parseContextPost(blogSource(header.join("\n")))).toThrow();
+  });
+});

--- a/packages/cli/src/image-key.test.ts
+++ b/packages/cli/src/image-key.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { imageKey } from "./image-key";
+
+/**
+ * `imageKey` is deliberately duplicated in packages/backend/src/image-key.ts
+ * (Web Crypto there, node:crypto here). A drift between the two silently
+ * orphans every R2 object, so the hash is pinned to a literal value.
+ */
+describe("imageKey (contract shared with packages/backend/src/image-key.ts)", () => {
+  it("hashes content/slug/file with sha256, matching the backend implementation", () => {
+    // printf "blog/hello/a.png" | shasum -a 256
+    expect(imageKey("blog", "hello", "a.png")).toBe(
+      "834f3281cf719402abf26441d1c46b6eb35de610de51e575c8df8180947ec2d3",
+    );
+  });
+
+  it("agrees with Web Crypto sha256, the primitive the backend uses", async () => {
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode("context/nix/setup.webp"),
+    );
+    const hex = [...new Uint8Array(digest)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    expect(imageKey("context", "nix", "setup.webp")).toBe(hex);
+  });
+
+  it("distinguishes the content kind, the slug and the file name", () => {
+    const keys = new Set([
+      imageKey("blog", "hello", "a.png"),
+      imageKey("context", "hello", "a.png"),
+      imageKey("blog", "hello2", "a.png"),
+      imageKey("blog", "hello", "b.png"),
+    ]);
+    expect(keys.size).toBe(4);
+  });
+});

--- a/packages/cli/src/sync.test.ts
+++ b/packages/cli/src/sync.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteBlog, RemoteContext, RemoteImage } from "./api";
+import type { LocalBlog, LocalContext } from "./content";
+import { imageKey } from "./image-key";
+import {
+  collectLocalImages,
+  isEmptyPlan,
+  type LocalImage,
+  planSync,
+  type SyncPlan,
+} from "./sync";
+
+const localBlog = (overrides: Partial<LocalBlog> = {}): LocalBlog => ({
+  slug: "hello",
+  title: "Hello",
+  image: "cover.png",
+  description: "A post",
+  published: true,
+  content: "# Body",
+  images: ["cover.png"],
+  dir: "content/blog/hello",
+  ...overrides,
+});
+
+const remoteBlogOf = (local: LocalBlog): RemoteBlog => ({
+  slug: local.slug,
+  title: local.title,
+  image: local.image,
+  description: local.description,
+  published: local.published,
+  content: local.content,
+});
+
+const localContext = (overrides: Partial<LocalContext> = {}): LocalContext => ({
+  slug: "nix",
+  title: "Nix",
+  emoji: "❄️",
+  published: true,
+  content: "# Body",
+  images: [],
+  dir: "content/context/nix",
+  ...overrides,
+});
+
+const remoteContextOf = (local: LocalContext): RemoteContext => ({
+  slug: local.slug,
+  title: local.title,
+  emoji: local.emoji,
+  published: local.published,
+  content: local.content,
+});
+
+const localImage = (overrides: Partial<LocalImage> = {}): LocalImage => ({
+  content: "blog",
+  slug: "hello",
+  file: "cover.png",
+  path: "content/blog/hello/cover.png",
+  key: imageKey("blog", "hello", "cover.png"),
+  md5: "d41d8cd98f00b204e9800998ecf8427e",
+  ...overrides,
+});
+
+const plan = (input: {
+  localBlogs?: LocalBlog[];
+  localContexts?: LocalContext[];
+  localImages?: LocalImage[];
+  remoteBlogs?: RemoteBlog[];
+  remoteContexts?: RemoteContext[];
+  remoteImages?: RemoteImage[];
+}): SyncPlan =>
+  planSync({
+    localBlogs: input.localBlogs ?? [],
+    localContexts: input.localContexts ?? [],
+    localImages: input.localImages ?? [],
+    remoteBlogs: input.remoteBlogs ?? [],
+    remoteContexts: input.remoteContexts ?? [],
+    remoteImages: input.remoteImages ?? [],
+  });
+
+describe("planSync: blogs", () => {
+  it("upserts a blog that does not exist remotely", () => {
+    const local = localBlog();
+    expect(plan({ localBlogs: [local] }).blogUpserts).toEqual([local]);
+  });
+
+  it("skips a blog whose remote copy is identical", () => {
+    const local = localBlog();
+    const result = plan({
+      localBlogs: [local],
+      remoteBlogs: [remoteBlogOf(local)],
+    });
+    expect(result.blogUpserts).toEqual([]);
+    expect(result.blogDeletes).toEqual([]);
+  });
+
+  it.each([
+    ["title", { title: "Changed" }],
+    ["image", { image: "other.png" }],
+    ["description", { description: "Changed" }],
+    ["published", { published: false }],
+    ["content", { content: "# Changed" }],
+  ] satisfies [string, Partial<LocalBlog>][])(
+    "upserts a blog when %s differs",
+    (_field, change) => {
+      const remote = remoteBlogOf(localBlog());
+      const local = localBlog(change);
+      expect(
+        plan({ localBlogs: [local], remoteBlogs: [remote] }).blogUpserts,
+      ).toEqual([local]);
+    },
+  );
+
+  it("ignores local-only fields that the backend does not store", () => {
+    const remote = remoteBlogOf(localBlog());
+    const local = localBlog({
+      dir: "somewhere/else",
+      images: ["cover.png", "extra.png"],
+    });
+    expect(
+      plan({ localBlogs: [local], remoteBlogs: [remote] }).blogUpserts,
+    ).toEqual([]);
+  });
+
+  it("deletes a blog that only exists remotely", () => {
+    const local = localBlog();
+    const orphan = remoteBlogOf(localBlog({ slug: "gone" }));
+    const result = plan({
+      localBlogs: [local],
+      remoteBlogs: [remoteBlogOf(local), orphan],
+    });
+    expect(result.blogDeletes).toEqual(["gone"]);
+    expect(result.blogUpserts).toEqual([]);
+  });
+});
+
+describe("planSync: contexts", () => {
+  it("upserts a context that does not exist remotely", () => {
+    const local = localContext();
+    expect(plan({ localContexts: [local] }).contextUpserts).toEqual([local]);
+  });
+
+  it("skips a context whose remote copy is identical", () => {
+    const local = localContext();
+    expect(
+      plan({ localContexts: [local], remoteContexts: [remoteContextOf(local)] })
+        .contextUpserts,
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["title", { title: "Changed" }],
+    ["emoji", { emoji: "🐧" }],
+    ["published", { published: false }],
+    ["content", { content: "# Changed" }],
+  ] satisfies [string, Partial<LocalContext>][])(
+    "upserts a context when %s differs",
+    (_field, change) => {
+      const remote = remoteContextOf(localContext());
+      const local = localContext(change);
+      expect(
+        plan({ localContexts: [local], remoteContexts: [remote] })
+          .contextUpserts,
+      ).toEqual([local]);
+    },
+  );
+
+  it("deletes a context that only exists remotely", () => {
+    const orphan = remoteContextOf(localContext({ slug: "gone" }));
+    expect(plan({ remoteContexts: [orphan] }).contextDeletes).toEqual(["gone"]);
+  });
+});
+
+describe("planSync: images", () => {
+  it("skips an image whose remote etag equals the local md5", () => {
+    const image = localImage({ md5: "abc" });
+    const result = plan({
+      localImages: [image],
+      remoteImages: [{ key: image.key, etag: "abc" }],
+    });
+    expect(result.imageUploads).toEqual([]);
+    expect(result.imageDeletes).toEqual([]);
+  });
+
+  it("strips the double quotes R2 wraps the etag in", () => {
+    const image = localImage({ md5: "abc" });
+    expect(
+      plan({
+        localImages: [image],
+        remoteImages: [{ key: image.key, etag: '"abc"' }],
+      }).imageUploads,
+    ).toEqual([]);
+  });
+
+  it("uploads an image whose remote etag differs from the local md5", () => {
+    const image = localImage({ md5: "abc" });
+    expect(
+      plan({
+        localImages: [image],
+        remoteImages: [{ key: image.key, etag: '"def"' }],
+      }).imageUploads,
+    ).toEqual([image]);
+  });
+
+  it("uploads an image that does not exist remotely", () => {
+    const image = localImage();
+    expect(plan({ localImages: [image] }).imageUploads).toEqual([image]);
+  });
+
+  it("deletes an image that only exists remotely", () => {
+    const image = localImage({ md5: "abc" });
+    const orphanKey = imageKey("blog", "hello", "orphan.png");
+    const result = plan({
+      localImages: [image],
+      remoteImages: [
+        { key: image.key, etag: '"abc"' },
+        { key: orphanKey, etag: '"whatever"' },
+      ],
+    });
+    expect(result.imageDeletes).toEqual([orphanKey]);
+    expect(result.imageUploads).toEqual([]);
+  });
+});
+
+describe("collectLocalImages", () => {
+  it("keys every image by content kind, slug and file name", () => {
+    const blogs = [
+      localBlog({ slug: "hello", images: ["cover.png", "a.png"] }),
+    ];
+    const contexts = [
+      localContext({
+        slug: "nix",
+        images: ["setup.webp"],
+        dir: "content/context/nix",
+      }),
+    ];
+    expect(
+      collectLocalImages(blogs, contexts, (path) => `md5:${path}`),
+    ).toEqual([
+      {
+        content: "blog",
+        slug: "hello",
+        file: "cover.png",
+        path: "content/blog/hello/cover.png",
+        key: imageKey("blog", "hello", "cover.png"),
+        md5: "md5:content/blog/hello/cover.png",
+      },
+      {
+        content: "blog",
+        slug: "hello",
+        file: "a.png",
+        path: "content/blog/hello/a.png",
+        key: imageKey("blog", "hello", "a.png"),
+        md5: "md5:content/blog/hello/a.png",
+      },
+      {
+        content: "context",
+        slug: "nix",
+        file: "setup.webp",
+        path: "content/context/nix/setup.webp",
+        key: imageKey("context", "nix", "setup.webp"),
+        md5: "md5:content/context/nix/setup.webp",
+      },
+    ]);
+  });
+
+  it("hashes each image exactly once", () => {
+    const seen: string[] = [];
+    collectLocalImages(
+      [localBlog({ images: ["cover.png", "a.png"] })],
+      [],
+      (path) => {
+        seen.push(path);
+        return "md5";
+      },
+    );
+    expect(seen).toEqual([
+      "content/blog/hello/cover.png",
+      "content/blog/hello/a.png",
+    ]);
+  });
+
+  it("returns nothing when no post has an image", () => {
+    expect(collectLocalImages([], [], () => "md5")).toEqual([]);
+  });
+});
+
+describe("isEmptyPlan", () => {
+  it("is true when nothing has to be done", () => {
+    expect(isEmptyPlan(plan({}))).toBe(true);
+  });
+
+  it.each([
+    ["blogUpserts", { localBlogs: [localBlog()] }],
+    ["blogDeletes", { remoteBlogs: [remoteBlogOf(localBlog())] }],
+    ["contextUpserts", { localContexts: [localContext()] }],
+    ["contextDeletes", { remoteContexts: [remoteContextOf(localContext())] }],
+    ["imageUploads", { localImages: [localImage()] }],
+    ["imageDeletes", { remoteImages: [{ key: "orphan", etag: '"abc"' }] }],
+  ])("is false when %s is not empty", (_field, input) => {
+    expect(isEmptyPlan(plan(input))).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     ulidx:
       specifier: ^2.4.1
       version: 2.4.1
+    vitest:
+      specifier: ^4.1.10
+      version: 4.1.10
     wrangler:
       specifier: 4.118.0
       version: 4.118.0
@@ -170,6 +173,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0))
 
   packages/drizzle:
     dependencies:
@@ -1914,6 +1920,9 @@ packages:
       rclone.js:
         optional: true
 
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
   '@oxfmt/binding-android-arm-eabi@0.62.0':
     resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2300,6 +2309,93 @@ packages:
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -2492,6 +2588,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2535,8 +2634,14 @@ packages:
   '@tsconfig/node18@1.0.3':
     resolution: {integrity: sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2590,6 +2695,35 @@ packages:
 
   '@urql/core@5.2.0':
     resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vue/compiler-core@3.5.34':
     resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
@@ -2689,6 +2823,10 @@ packages:
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2805,6 +2943,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -2909,6 +3051,9 @@ packages:
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -3180,6 +3325,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3273,6 +3421,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -3656,6 +3808,76 @@ packages:
 
   layerr@3.0.0:
     resolution: {integrity: sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
 
   lil-fp@1.4.5:
     resolution: {integrity: sha512-RrMQ2dB7SDXriFPZMMHEmroaSP6lFw3QEV7FOfSkf19kvJnDzHqKMc2P9HOf5uE8fOp5YxodSrq7XxWjdeC2sw==}
@@ -4095,6 +4317,10 @@ packages:
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4233,6 +4459,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
@@ -4457,6 +4687,11 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -4546,6 +4781,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4583,9 +4821,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@3.1.0:
     resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
@@ -4671,9 +4915,24 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4834,6 +5093,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.28.1
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -4862,6 +5205,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wonka@6.3.6:
@@ -6512,6 +6860,8 @@ snapshots:
       - encoding
       - supports-color
 
+  '@oxc-project/types@0.143.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.62.0':
     optional: true
 
@@ -6880,6 +7230,50 @@ snapshots:
 
   '@repeaterjs/repeater@3.0.6': {}
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -7128,6 +7522,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -7153,9 +7549,16 @@ snapshots:
 
   '@tsconfig/node18@1.0.3': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -7212,6 +7615,47 @@ snapshots:
       wonka: 6.3.6
     transitivePeerDependencies:
       - graphql
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vue/compiler-core@3.5.34':
     dependencies:
@@ -7325,6 +7769,8 @@ snapshots:
       sprintf-js: 1.0.3
 
   array-timsort@1.0.3: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -7448,6 +7894,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -7551,6 +7999,8 @@ snapshots:
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -7703,6 +8153,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7906,6 +8358,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   express@5.2.1:
     dependencies:
@@ -8390,6 +8844,55 @@ snapshots:
   kleur@4.1.5: {}
 
   layerr@3.0.0: {}
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lil-fp@1.4.5: {}
 
@@ -9086,6 +9589,8 @@ snapshots:
 
   obliterator@1.6.1: {}
 
+  obug@2.1.4: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -9231,6 +9736,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pify@4.0.1: {}
 
@@ -9533,6 +10040,26 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -9706,6 +10233,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9735,7 +10264,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-width@3.1.0:
     dependencies:
@@ -9827,7 +10360,18 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -9992,6 +10536,50 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.19
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.99.0
+      terser: 5.16.9
+      tsx: 4.22.1
+      yaml: 2.9.0
+
+  vitest@4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.99.0)(terser@5.16.9)(tsx@4.22.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - msw
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
@@ -10017,6 +10605,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wonka@6.3.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   tsx: ^4.19.2
   typescript: ~5.7.2
   ulidx: ^2.4.1
+  vitest: ^4.1.10
   wrangler: 4.118.0
   zod: ^3.24.0
 # Security floors for transitive dependencies (pnpm audit, 2026-08-03).


### PR DESCRIPTION
## 概要

テストが 1 つも存在しない状態を解消するため、vitest を導入して最初のユニットテストを追加する。

このPRのスコープは **テスト基盤の整備 + `packages/cli` の純 TS ロジックのテスト** に限定した。
sync CLI は「D1 と R2 を content ディレクトリに合わせて破壊的に同期する」処理であり、ロジックのバグがそのまま記事や画像の消失につながる。かつ全体が副作用のない純関数として切り出されているため、テスト基盤の最初の適用先として選んだ。

## 基盤

- `pnpm-workspace.yaml` の catalog に `vitest: ^4.1.10` を追加
- `packages/cli` に `"test": "vitest run"` と `"vitest": "catalog:"` を追加
- ルート `package.json` に `"test": "pnpm -r run test"` を追加
  - `test` スクリプトを持つパッケージだけが走るため、対象パッケージを増やしても設定変更は不要
- `.github/workflows/ci.yaml` に既存ジョブと同形式の `test` ジョブを追加(`nix develop .#ci --command pnpm run test`)
- vitest の設定ファイルは置いていない。デフォルトの include (`**/*.test.ts`) と `packages/cli/tsconfig.json` の `include: ["src"]` がそのまま噛み合うため

> [!NOTE]
> issue #28 には「turbo に `test` タスクを定義」とあるが、turbo は撤去済みのためプレーンな pnpm スクリプト構成に読み替えた。

## テスト内容(4 ファイル / 65 ケース)

### `src/frontmatter.test.ts`

- `splitFrontmatter`: 正常系、本文が空、**本文中の `---` を終端と誤認しないこと**、開始 `---` 欠落、終了 `---` 欠落、CRLF 改行の正規化
- `parseBlogPost` / `parseContextPost`: 正常系と、zod バリデーション失敗のケース(空文字列 / フィールド欠落 / `published` が boolean でない)を `it.each` で網羅

### `src/image-key.test.ts`

`imageKey` は `packages/backend/src/image-key.ts` と意図的に二重実装されている(backend は Web Crypto、CLI は `node:crypto`)。両者がずれると R2 上の全オブジェクトが静かに孤児化するため、コントラクトテストとして固定値を打ち込んだ。

- `printf "blog/hello/a.png" | shasum -a 256` の結果とリテラル比較
- `crypto.subtle.digest("SHA-256", ...)`(backend 側 `hono/utils/crypto` の `sha256` が使う primitive)と一致すること
- content 種別 / slug / ファイル名がそれぞれキーに効いていること

### `src/sync.test.ts`

- `planSync`(記事): 新規 → upsert / リモートと一致 → 対象外 / 各フィールド1つだけ変更 → upsert(blog 5 フィールド・context 4 フィールドを `it.each` で網羅)/ backend が保持しないローカル専用フィールド(`dir`, `images`)の差分は無視 / ローカルに無い → delete
- `planSync`(画像): etag と md5 が一致 → スキップ / 不一致 → upload / リモートに無い → upload / ローカルに無い → delete / **R2 が etag を包むダブルクォートの除去**
- `collectLocalImages`: `md5Of` を注入して、key と path の組み立て・ハッシュ回数・空入力を検証
- `isEmptyPlan`: 全部空 → true、6 フィールドそれぞれが非空 → false

### `src/content.test.ts`

`mkdtempSync` で実ファイルを書いて検証。

- `loadBlogs`: 正常系 / **`post.md` を images に含めないこと** / slug と画像名のソート / 未公開記事も読み込むこと / frontmatter の `image` がディレクトリに存在しない場合のエラー / frontmatter 不正時にファイルパスがエラーに含まれること / `blog/` 不存在 → 空配列
- `loadContexts`: 正常系 / context は画像参照必須でないこと / `post.md` 除外 / frontmatter 不正 / `context/` 不存在 → 空配列 / `blog/` を拾わないこと

## 検証

| コマンド | 結果 |
| --- | --- |
| `pnpm run test` | 4 files / 65 tests passed |
| `pnpm run typecheck` | pass |
| `pnpm run lint` | 新規の指摘なし(既存の warning のみ) |
| `pnpm run format:check` | pass |
| `actionlint .github/workflows/ci.yaml` | pass |

テストが実際に回帰を検知することを確認するため、`blogChanged` から `local.published !== remote.published` を一時的に削除したところ、該当ケースのみが失敗した(64 passed / 1 failed)。commit 8ef7e8e まで潜伏していた published 系のバグと同種の変更を捕捉できている。

## 今後の拡張(このPRのスコープ外)

issue #28 の優先順のうち、残りは別PRで進める。

- [ ] frontend の fetch 層(`features/blog/fetch.ts` / `features/context/fetch.ts`)の published フィルタ等
- [ ] GraphQL リゾルバのテスト(`@cloudflare/vitest-pool-workers` で D1 込み)。ランナーの構成が CLI とは別物になるため分離した
- [ ] deploy パイプラインへの test 組み込み。`deploy.yaml` は現在別作業で変更中のため本PRでは触っていない

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK
