### PR TITLE
fix(frontend): restore type safety

### DIFF
--- a/packages/frontend/next.config.mjs
+++ b/packages/frontend/next.config.mjs
@@ -2,9 +2,6 @@ import path from "node:path";
 
 /** @type {import('next').NextConfig} */
 const next_config = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   // Next 15 externalizes shiki by default, which makes OpenNext inline the
   // whole package (every grammar and theme) into the Cloudflare worker and
   // exceed its size limit. Opt shiki back into webpack bundling so only the

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,6 @@
     "@fontsource-variable/noto-sans-jp": "^5.1.0",
     "@mdx-js/mdx": "^3.0.1",
     "@pandacss/dev": "catalog:",
-    "@t3-oss/env-nextjs": "^0.13.11",
     "@types/mdast": "^4.0.4",
     "feed": "^4.2.2",
     "hono": "catalog:",

--- a/packages/frontend/src/features/markdown/compile_mdx.ts
+++ b/packages/frontend/src/features/markdown/compile_mdx.ts
@@ -58,7 +58,6 @@ export async function compile_mdx({
           footnoteLabel: "脚注",
           footnoteLabelTagName: "span",
           handlers: {
-            // @ts-expect-error FIXME: Why?
             linkcard: linkcard_handler,
           },
         },

--- a/packages/frontend/src/features/markdown/highlighter.ts
+++ b/packages/frontend/src/features/markdown/highlighter.ts
@@ -64,9 +64,10 @@ export const get_highlighter = async (
   });
   return {
     ...highlighter,
-    // rehype-pretty-code calls loadLanguage with bundle language names, which
-    // a core highlighter cannot resolve. All languages are preloaded above, so
-    // this is a no-op.
+    // rehype-pretty-code may call the loaders with bundled names, which a core
+    // highlighter cannot resolve. Every language and theme it can ask for is
+    // already preloaded above, so both are no-ops.
     loadLanguage: async () => {},
-  } as unknown as Highlighter;
+    loadTheme: async () => {},
+  };
 };

--- a/packages/frontend/src/features/markdown/lib/mdast-extensions.d.ts
+++ b/packages/frontend/src/features/markdown/lib/mdast-extensions.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Custom mdast nodes produced by our remark transformers. Registering them in
+ * RootContentMap makes them part of mdast's Nodes union, which is what
+ * mdast-util-to-hast keys its `handlers` record by.
+ */
+import type { Parent, PhrasingContent } from "mdast";
+import type { Node } from "unist";
+
+declare module "mdast" {
+  // remark_zenn_message: ":::message ... :::" paragraph → message node
+  interface ZennMessage extends Parent {
+    type: "message";
+    children: PhrasingContent[];
+  }
+
+  // remark_linkcard: bare-link paragraph → linkcard node
+  interface Linkcard extends Node {
+    type: "linkcard";
+    data?: {
+      hProperties: {
+        url: string;
+      };
+    };
+  }
+
+  interface RootContentMap {
+    message: ZennMessage;
+    linkcard: Linkcard;
+  }
+}

--- a/packages/frontend/src/features/markdown/lib/remark_linkcard.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_linkcard.ts
@@ -1,6 +1,6 @@
+import type { Parent } from "mdast";
 import type { Handler } from "mdast-util-to-hast";
 import type { Transformer } from "unified";
-import type { Parent } from "unist";
 import { visit } from "unist-util-visit";
 import { is_linkcard, is_parent } from "./utils";
 

--- a/packages/frontend/src/features/markdown/lib/remark_zenn_message.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_zenn_message.ts
@@ -1,7 +1,6 @@
-import type { Paragraph } from "mdast";
+import type { Paragraph, Parent } from "mdast";
 import type { Handler } from "mdast-util-to-hast";
 import type { Transformer } from "unified";
-import type { Parent } from "unist";
 import { visit } from "unist-util-visit";
 
 import { is_paragraph, is_parent, is_text } from "./utils";
@@ -57,7 +56,7 @@ export const remark_zenn_message = (): Transformer => {
       parent.children[index as number] = {
         type: "message",
         children,
-      } as any; // FIXME: Remove any
+      };
     });
   };
 };

--- a/packages/frontend/src/libs/env.ts
+++ b/packages/frontend/src/libs/env.ts
@@ -1,21 +1,40 @@
-// import { createEnv } from "@t3-oss/env-nextjs";
-// import { z } from "zod";
+import { z } from "zod";
 
-// export const env = createEnv({
-//   server: {
-//     BACKEND_URL: z.string().url(),
-//     BACKEND_API_TOKEN: z.string(),
-//     FRONTEND_URL: z.string().url(),
-//     FRONTEND_API_TOKEN: z.string(),
-//   },
-//   experimental__runtimeEnv: process.env,
-// });
+const shape = {
+  BACKEND_URL: z.string().url(),
+  BACKEND_API_TOKEN: z.string().min(1),
+  FRONTEND_URL: z.string().url(),
+  FRONTEND_API_TOKEN: z.string().min(1),
+};
 
-export type Env = Readonly<{
-  BACKEND_URL: string;
-  BACKEND_API_TOKEN: string;
-  FRONTEND_URL: string;
-  FRONTEND_API_TOKEN: string;
-}>;
+type Key = keyof typeof shape;
 
-export const env = process.env as unknown as Env;
+export type Env = Readonly<Record<Key, string>>;
+
+// The CI smoke build (ALLOW_EMPTY_CONTENT=1) runs without a backend and
+// without secrets; hand it inert-but-wellformed values so module init and
+// `new URL(...)` still work. Everything else gets validated on first access.
+const smoke: Env = {
+  BACKEND_URL: "http://smoke-build.invalid",
+  BACKEND_API_TOKEN: "smoke-build",
+  FRONTEND_URL: "http://smoke-build.invalid",
+  FRONTEND_API_TOKEN: "smoke-build",
+};
+
+// Lazy per-key validation: on Cloudflare, process.env is populated from the
+// worker env at request time, so an eager module-scope parse would run too
+// early (and would also break `next build`, which imports modules while
+// collecting page data).
+export const env: Env = new Proxy({} as Env, {
+  get(_target, key: string) {
+    if (!(key in shape)) return undefined;
+    if (process.env.ALLOW_EMPTY_CONTENT === "1") return smoke[key as Key];
+    const result = shape[key as Key].safeParse(process.env[key]);
+    if (!result.success) {
+      throw new Error(
+        `Invalid environment variable ${key}: ${result.error.issues[0]?.message}`,
+      );
+    }
+    return result.data;
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,9 +226,6 @@ importers:
       '@pandacss/dev':
         specifier: 'catalog:'
         version: 0.22.1(typescript@5.7.3)
-      '@t3-oss/env-nextjs':
-        specifier: ^0.13.11
-        version: 0.13.11(typescript@5.7.3)(zod@3.25.76)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -2409,40 +2406,6 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
-  '@t3-oss/env-core@0.13.11':
-    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
-    peerDependencies:
-      arktype: ^2.1.0
-      typescript: '>=5.0.0'
-      valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
-    peerDependenciesMeta:
-      arktype:
-        optional: true
-      typescript:
-        optional: true
-      valibot:
-        optional: true
-      zod:
-        optional: true
-
-  '@t3-oss/env-nextjs@0.13.11':
-    resolution: {integrity: sha512-NC+3j7YWgpzdFu1t5y/8wqibTK0lm5RS4bjXA1n8uwik3wIR4iZM4Fa+U2BaMa5k3Qk8RZiYhoAIX0WogmGkzg==}
-    peerDependencies:
-      arktype: ^2.1.0
-      typescript: '>=5.0.0'
-      valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
-    peerDependenciesMeta:
-      arktype:
-        optional: true
-      typescript:
-        optional: true
-      valibot:
-        optional: true
-      zod:
-        optional: true
 
   '@ts-morph/common@0.20.0':
     resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
@@ -7190,18 +7153,6 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
-
-  '@t3-oss/env-core@0.13.11(typescript@5.7.3)(zod@3.25.76)':
-    optionalDependencies:
-      typescript: 5.7.3
-      zod: 3.25.76
-
-  '@t3-oss/env-nextjs@0.13.11(typescript@5.7.3)(zod@3.25.76)':
-    dependencies:
-      '@t3-oss/env-core': 0.13.11(typescript@5.7.3)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.7.3
-      zod: 3.25.76
 
   '@ts-morph/common@0.20.0':
     dependencies:


### PR DESCRIPTION
Closes #29

## 変更内容

issue の 4 項目すべてに対応(型逃げの完全ゼロ化):

### 1. `ignoreBuildErrors` 撤廃
`next build` が型チェック(`.next/types` のルート検証込み)で落ちるようになった。deploy パイプラインの build ジョブがそのまま型ゲートとして機能する。

### 2. env.ts のバリデーション復活
`process.env as unknown as Env` の素通しを、**Proxy による lazy な per-key zod 検証**に置き換え。

- 欠落・不正(URL でない等)は初回アクセス時に `Invalid environment variable BACKEND_URL: ...` で即失敗(これまでは undefined が下流に流れて意味不明なエラーになっていた)
- lazy にした理由: Cloudflare Workers では process.env への注入がリクエスト時なので、モジュールスコープでの eager parse は早すぎる(`next build` のページデータ収集でも落ちる)
- CI スモークビルド(`ALLOW_EMPTY_CONTENT=1`)には well-formed なプレースホルダ(`http://smoke-build.invalid`)を返す — スモークビルドの概念が env.ts 一箇所に明示された
- この方式なら `@t3-oss/env-nextjs` は不要なので依存ごと削除(#32 の保留項目の解消)

検証: 不正→throw / 正常→素通し / スモーク→placeholder の 3 経路を tsx で実地確認済み。

### 3. hono/vercel の型衝突 → 上流で解消済みを確認
`next build` 後に `.next/types` がある状態で `tsc` を実行しても再現しない(validator に `/api/[[...route]]` は含まれている)。hono 4.12.x / Next 15.5.x への更新で直った模様。コード変更なし。

### 4. FIXME 型ごまかし 3 件の解消
- **mdast module augmentation**(`mdast-extensions.d.ts` 新設)で独自ノード `message` / `linkcard` を `RootContentMap` に登録。これで:
  - `remark_zenn_message` の `as any` → 不要(mdast の `Parent` に変更して代入が正しく型付け)
  - `compile_mdx` の `@ts-expect-error FIXME: Why?` → 原因は `handlers` のキーが `Nodes['type']` union に限定されているのに `linkcard` が未登録だったこと。登録により解消
- **highlighter** の `as unknown as Highlighter` → `loadTheme` も no-op スタブにすることでキャストなしで構造的に適合(テーマも言語も全て事前ロード済みなので意味的にも正しい)。唯一の非互換は `loadTheme` がアロー関数プロパティで反変チェックされることだった

## 検証

- `ALLOW_EMPTY_CONTENT=1 pnpm run build`(型チェック有効で exit 0)
- `pnpm run typecheck` / `test`(65 passed)/ `lint`(新規指摘なし)/ `format:check` すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK