### PR TITLE
ci: add worker bundle-size budgets and workerd smoke tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,21 @@ jobs:
       - name: Test
         run: nix develop .#ci --command pnpm run test
 
+  workers-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Generate
+        run: nix develop .#ci --command pnpm run gen
+      # Bundle-size budgets + workerd smoke over the production bundling
+      # path (opennextjs-cloudflare), which a plain `next build` never
+      # exercises — see issue #31.
+      - name: Check worker bundles
+        run: nix develop .#ci --command scripts/workers-check.sh
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Build Outputs
 dist
+.size-check
 
 # Generated (pnpm run gen)
 packages/*/worker-configuration.d.ts

--- a/scripts/workers-check.sh
+++ b/scripts/workers-check.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Builds both Workers through the production bundling path, enforces gzip
+# bundle-size budgets, and smoke-tests each bundle in workerd (wrangler dev).
+#
+# Rationale (issue #31): the three production-only 500s — worker over the
+# 3 MiB gzip limit, workerd's eval() ban breaking the MDX runtime, and the
+# POST-fetch data-cache collision — were all invisible to a plain `next build`.
+# This script exercises the real bundle in the real runtime instead.
+#
+# Usage: scripts/workers-check.sh   (from anywhere; needs pnpm deps installed
+# and generated files present — run `pnpm run gen` first)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Cloudflare's limit is 3 MiB gzip per Worker. Budgets leave headroom so
+# growth is caught in a PR, not at the limit.
+FRONTEND_BUDGET=2800000
+BACKEND_BUDGET=1000000
+
+BACKEND_PORT=8791
+FRONTEND_PORT=8792
+
+cleanup() {
+  pkill -f "wrangler dev.*--port $BACKEND_PORT" 2>/dev/null || true
+  pkill -f "wrangler dev.*--port $FRONTEND_PORT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Largest .js in a dry-run outdir is the entry bundle (name follows the
+# wrangler `main` entry, e.g. main.js / worker.js).
+bundle_of() {
+  find "$1" -maxdepth 1 -name "*.js" -exec ls -S {} + | head -1
+}
+
+gzip_size() {
+  gzip -c "$1" | wc -c | tr -d ' '
+}
+
+check_budget() { # label size budget
+  if [ "$2" -gt "$3" ]; then
+    echo "FAIL: $1 bundle ${2} bytes gzip exceeds budget ${3}"
+    exit 1
+  fi
+  echo "OK: $1 bundle ${2} bytes gzip (budget ${3})"
+}
+
+wait_for() { # url expected_status timeout_sec
+  local deadline=$((SECONDS + $3))
+  while [ $SECONDS -lt $deadline ]; do
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" -m 3 "$1" 2>/dev/null || true)
+    [ "$code" = "$2" ] && return 0
+    sleep 2
+  done
+  echo "FAIL: $1 did not return $2 within $3 seconds (last: ${code:-none})"
+  return 1
+}
+
+expect() { # url expected_status
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" -m 15 "$1")
+  if [ "$code" != "$2" ]; then
+    echo "FAIL: GET $1 -> $code (expected $2)"
+    exit 1
+  fi
+  echo "OK: GET $1 -> $code"
+}
+
+echo "=== backend: bundle size ==="
+(cd "$ROOT/packages/backend" && pnpm exec wrangler deploy --dry-run --outdir .size-check >/dev/null 2>&1)
+check_budget backend "$(gzip_size "$(bundle_of "$ROOT/packages/backend/.size-check")")" "$BACKEND_BUDGET"
+
+echo "=== frontend: production bundle (opennextjs-cloudflare) ==="
+(cd "$ROOT/packages/frontend" && ALLOW_EMPTY_CONTENT=1 pnpm run build:prod >/dev/null)
+(cd "$ROOT/packages/frontend" && pnpm exec wrangler deploy --dry-run --outdir .size-check >/dev/null 2>&1)
+check_budget frontend "$(gzip_size "$(bundle_of "$ROOT/packages/frontend/.size-check")")" "$FRONTEND_BUDGET"
+
+echo "=== backend: workerd smoke ==="
+(cd "$ROOT/packages/backend" && pnpm exec wrangler dev --port $BACKEND_PORT \
+  --var BACKEND_API_TOKEN:smoke --var FRONTEND_API_TOKEN:smoke \
+  --var FRONTEND_URL:http://smoke.invalid >/dev/null 2>&1 &)
+# Unauthenticated /graphql returning 401 proves the worker booted and routed.
+wait_for "http://127.0.0.1:$BACKEND_PORT/graphql" 401 60
+
+echo "=== frontend: workerd smoke ==="
+(cd "$ROOT/packages/frontend" && pnpm exec wrangler dev --port $FRONTEND_PORT \
+  --var BACKEND_URL:http://smoke.invalid --var BACKEND_API_TOKEN:smoke \
+  --var FRONTEND_URL:http://smoke.invalid --var FRONTEND_API_TOKEN:smoke \
+  --var ALLOW_EMPTY_CONTENT:1 >/dev/null 2>&1 &)
+wait_for "http://127.0.0.1:$FRONTEND_PORT/" 200 90
+expect "http://127.0.0.1:$FRONTEND_PORT/blog" 200
+expect "http://127.0.0.1:$FRONTEND_PORT/rss.xml" 200
+
+echo "workers-check: all green"


### PR DESCRIPTION
Closes #31

## 目的

過去に本番でのみ発火した 500 の 3 原因(Worker の 3 MiB gzip 超過 / workerd の `eval()` 禁止 / data cache の POST fetch 衝突)は、CI が本番のバンドル経路(opennextjs-cloudflare)を一切通らないため検知不能だった。実バンドル・実ランタイムで検証する CI ジョブを追加する。

## 変更内容

**`scripts/workers-check.sh`**(ローカルでも実行可能):

1. **バンドルサイズバジェット** — `wrangler deploy --dry-run` で実際のアップロード対象バンドルを生成し gzip サイズを予算と比較
   - frontend: **現在 1.84 MiB** / 予算 2.8 MB(上限 3 MiB の手前で PR 段階検知)
   - backend: 現在 203 KB / 予算 1 MB
   - shiki の fine-grained import 回避策が依存更新で崩れた場合、ここで落ちる(#34 の shiki 4 / Next 16 更新の前提ガード)
2. **workerd スモーク** — 本番ビルドを `wrangler dev`(workerd)で起動し実応答を確認
   - backend: 未認証 `/graphql` → 401(起動・ルーティングの証明)
   - frontend: `/`・`/blog`・`/rss.xml` → 200(モジュール初期化・opennext ランタイムの検証)

**`ci.yaml`** に `workers-check` ジョブ(PR ゲート、timeout 15min)。deploy パイプラインには追加せず、PR 段階での検知に限定(main は全て PR 経由のため)。

## 既知の制約(今後の拡張)

- スモークは `ALLOW_EMPTY_CONTENT=1` のため**ブログ詳細ページ(MDX レンダリング経路)は踏めない**。eval() 問題の完全な再現にはフィクスチャ記事の注入が必要で、別途拡張候補
- issue #31 の「staging 自動デプロイ + ヘルスチェック」は #35(環境分離)前提のため、#35 側で扱う
- opennextjs build 中に pnpm store のシンボリックリンク由来の "Failed to copy" ログが出るが、ビルドは成功しスモークも通る(既存挙動、本 PR とは無関係)

## 検証

- ローカルでスクリプト全経路 green(サイズ 2 件 OK・スモーク 3 エンドポイント OK・exit 0)
- actionlint 警告ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK