### PR TITLE
chore(deps): update zod to 4.x and @hono/zod-validator to 0.9

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@asa1984.dev/drizzle": "workspace:*",
     "@asa1984.dev/graphql": "workspace:*",
-    "@hono/zod-validator": "0.4.3",
+    "@hono/zod-validator": "0.9.0",
     "graphql": "catalog:",
     "graphql-yoga": "5.21.2",
     "hono": "catalog:",

--- a/packages/frontend/src/libs/env.ts
+++ b/packages/frontend/src/libs/env.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 const shape = {
-  BACKEND_URL: z.string().url(),
+  BACKEND_URL: z.url(),
   BACKEND_API_TOKEN: z.string().min(1),
-  FRONTEND_URL: z.string().url(),
+  FRONTEND_URL: z.url(),
   FRONTEND_API_TOKEN: z.string().min(1),
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ catalogs:
       specifier: 4.121.0
       version: 4.121.0
     zod:
-      specifier: 3.25.76
-      version: 3.25.76
+      specifier: 4.4.3
+      version: 4.4.3
 
 overrides:
   fast-xml-parser@4: ^4.5.5
@@ -113,8 +113,8 @@ importers:
         specifier: workspace:*
         version: link:../graphql
       '@hono/zod-validator':
-        specifier: 0.4.3
-        version: 0.4.3(hono@4.13.1)(zod@3.25.76)
+        specifier: 0.9.0
+        version: 0.9.0(hono@4.13.1)(zod@4.4.3)
       graphql:
         specifier: 'catalog:'
         version: 16.14.0
@@ -129,7 +129,7 @@ importers:
         version: 2.4.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@asa1984.dev/tsconfig':
         specifier: workspace:*
@@ -160,7 +160,7 @@ importers:
         version: 2.9.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@asa1984.dev/tsconfig':
         specifier: workspace:*
@@ -300,7 +300,7 @@ importers:
         version: 4.2.2(@urql/core@5.2.0(graphql@16.14.0))(react@19.2.8)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@asa1984.dev/tsconfig':
         specifier: workspace:*
@@ -1287,11 +1287,11 @@ packages:
     resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
     engines: {node: '>=18.0.0'}
 
-  '@hono/zod-validator@0.4.3':
-    resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
+  '@hono/zod-validator@0.9.0':
+    resolution: {integrity: sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug==}
     peerDependencies:
-      hono: '>=3.9.0'
-      zod: ^3.19.1
+      hono: '>=4.11.2'
+      zod: ^3.25.0 || ^4.0.0
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -5052,8 +5052,8 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -6083,10 +6083,10 @@ snapshots:
       '@repeaterjs/repeater': 3.0.6
       tslib: 2.8.1
 
-  '@hono/zod-validator@0.4.3(hono@4.13.1)(zod@3.25.76)':
+  '@hono/zod-validator@0.9.0(hono@4.13.1)(zod@4.4.3)':
     dependencies:
       hono: 4.13.1
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@img/colour@1.1.0': {}
 
@@ -10285,6 +10285,6 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   ulidx: 2.4.1
   vitest: 4.1.10
   wrangler: 4.121.0
-  zod: 3.25.76
+  zod: 4.4.3
 # Security floors for transitive dependencies (pnpm audit, 2026-08-03).
 # Scoped per major so parents keep their expected API surface.
 overrides:


### PR DESCRIPTION
Refs #34

issue #34 のメジャー束 1。zod を 3 系から 4 系へ、あわせて `@hono/zod-validator` を 0.9 へ上げる。

## 変更点

| パッケージ | before | after | 管理場所 |
| --- | --- | --- | --- |
| `zod` | 3.25.76 | 4.4.3 | catalog (`pnpm-workspace.yaml`) |
| `@hono/zod-validator` | 0.4.3 | 0.9.0 | `packages/backend/package.json` |

いずれも exact 固定のポリシーどおり、範囲指定なしで記述している。
`@hono/zod-validator@0.9.0` の peer は `zod: ^3.25.0 || ^4.0.0` なので、両者の同時更新で整合する。

## 破壊的変更への対応

### `z.string().url()` → `z.url()`

zod 4 で string 系のフォーマットメソッドは deprecated となり、トップレベル関数に移動した。
`packages/frontend/src/libs/env.ts` の `BACKEND_URL` / `FRONTEND_URL` を `z.url()` に置き換えた。

### 影響がなかった箇所

- `safeParse` と `result.error.issues` — API は zod 4 でも同一。env proxy のエラーハンドリングは無変更で通る。
- `z.object` / `z.string().min(1)` / `z.boolean()` / `z.infer` (`packages/cli/src/frontmatter.ts`) — 変更不要。
- `zValidator("json", z.object({ key: z.string() }))` (`packages/backend/src/route/image.route.ts`) — 0.9 でも同じ呼び出し方で動く。バリデーション失敗時のレスポンスは 400 + `{ success: false, error: ZodError }` のままで、この形を読むコードはリポジトリ内に存在しない。
- vitest のテスト (cli 65 件) — zod のメッセージ文言に依存したアサーションはなく、文言変更による修正は不要だった。

なお `min(1)` 失敗時のメッセージは `String must contain at least 1 character(s)` から `Too small: expected string to have >=1 characters` に変わっているが、これを assert している箇所はない。

## 検証

すべて green。

- `pnpm run typecheck`
- `pnpm run test` — 4 files / 65 tests passed
- `pnpm run lint` — exit 0(既存の warning のみ、増減なし)
- `pnpm run format:check`
- `ALLOW_EMPTY_CONTENT=1 pnpm run build`
- `scripts/workers-check.sh` — all green
  - backend bundle: **267,068 bytes gzip**(budget 1,000,000)
  - frontend bundle: **1,851,125 bytes gzip**(budget 2,800,000)
  - workerd スモーク: backend `/graphql` → 401、frontend `/` `/blog` `/rss.xml` → 200

### env proxy の実挙動確認

`packages/frontend` で tsx から `env` を直接叩いて確認した。

- `BACKEND_URL=""` (strict): `Invalid environment variable BACKEND_URL: Invalid URL` を throw
- `BACKEND_API_TOKEN=""` (strict): `Invalid environment variable BACKEND_API_TOKEN: Too small: expected string to have >=1 characters` を throw
- `ALLOW_EMPTY_CONTENT=1`: placeholder (`http://smoke-build.invalid` / `smoke-build`) を返す
- 正常値 (`https://api.example.com`): そのまま返る
- shape 外のキー: `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK
