### PR TITLE
chore(deps): update pothos to v4

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@asa1984.dev/drizzle": "workspace:*",
-    "@pothos/core": "3.41.2",
-    "@pothos/plugin-simple-objects": "3.7.1",
+    "@pothos/core": "4.13.1",
+    "@pothos/plugin-simple-objects": "4.1.4",
     "graphql": "catalog:",
     "ulidx": "catalog:"
   },

--- a/packages/graphql/src/graphql/gql-builder.ts
+++ b/packages/graphql/src/graphql/gql-builder.ts
@@ -4,8 +4,12 @@ import type { GraphQLContext } from "../types";
 
 export const builder = new SchemaBuilder<{
   Context: GraphQLContext;
+  DefaultFieldNullability: false;
 }>({
   plugins: [SimpleObjectsPlugin],
+  // Pothos v4 flipped the default to nullable; keep the v3 behavior the
+  // schema was designed around (fields are non-nullable unless opted out).
+  defaultFieldNullability: false,
 });
 
 // REQUIRED: define root types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,11 +354,11 @@ importers:
         specifier: workspace:*
         version: link:../drizzle
       '@pothos/core':
-        specifier: 3.41.2
-        version: 3.41.2(graphql@16.14.0)
+        specifier: 4.13.1
+        version: 4.13.1(graphql@16.14.0)
       '@pothos/plugin-simple-objects':
-        specifier: 3.7.1
-        version: 3.7.1(@pothos/core@3.41.2(graphql@16.14.0))(graphql@16.14.0)
+        specifier: 4.1.4
+        version: 4.1.4(@pothos/core@4.13.1(graphql@16.14.0))(graphql@16.14.0)
       graphql:
         specifier: 'catalog:'
         version: 16.14.0
@@ -2120,16 +2120,16 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@pothos/core@3.41.2':
-    resolution: {integrity: sha512-iR1gqd93IyD/snTW47HwKSsRCrvnJaYwjVNcUG8BztZPqMxyJKPAnjPHAgu1XB82KEdysrNqIUnXqnzZIs08QA==}
+  '@pothos/core@4.13.1':
+    resolution: {integrity: sha512-2hkLxmvrT7VnbiWAfYhfF09PjaHeflZ5HrBHYzU6Tn/P9tDviuZS7IS5xO4k/KnK5GkRo3YxDzXyn+HnkEkVNw==}
     peerDependencies:
-      graphql: '>=15.1.0'
+      graphql: ^16.10.0 || ^17.0.0
 
-  '@pothos/plugin-simple-objects@3.7.1':
-    resolution: {integrity: sha512-641qxavEa4GJGIYfZuhOdlUy6MjQ/z0gWS5x4pSU72GIJFPSyMAFjHI8O413TzmMf4SpDGWPq0S6UNNXcrGCBQ==}
+  '@pothos/plugin-simple-objects@4.1.4':
+    resolution: {integrity: sha512-mkDn640l/y1u3wg7LRNr/HaCpQypGJwjokeoJeHLHNvxsIQ+vLOjpNgwoAb+DhUusa75xWjVnMsbGsIGEr3Z3w==}
     peerDependencies:
       '@pothos/core': '*'
-      graphql: '>=15.1.0'
+      graphql: ^16.10.0 || ^17.0.0
 
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
@@ -6861,13 +6861,13 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@pothos/core@3.41.2(graphql@16.14.0)':
+  '@pothos/core@4.13.1(graphql@16.14.0)':
     dependencies:
       graphql: 16.14.0
 
-  '@pothos/plugin-simple-objects@3.7.1(@pothos/core@3.41.2(graphql@16.14.0))(graphql@16.14.0)':
+  '@pothos/plugin-simple-objects@4.1.4(@pothos/core@4.13.1(graphql@16.14.0))(graphql@16.14.0)':
     dependencies:
-      '@pothos/core': 3.41.2(graphql@16.14.0)
+      '@pothos/core': 4.13.1(graphql@16.14.0)
       graphql: 16.14.0
 
   '@repeaterjs/repeater@3.0.6': {}


### PR DESCRIPTION
Refs #34(束 2 の前半。graphql 17 は graphql-yoga 未対応のため保留 — issue コメント参照)

## 変更

| package | before | after |
| --- | --- | --- |
| @pothos/core | 3.41.2 | 4.13.1 |
| @pothos/plugin-simple-objects | 3.7.1 | 4.1.4 |

いずれも exact 固定。graphql は 16.14.0 のまま(pothos 4 の peer は `^16.10 || ^17`)。

## 対応した破壊的変更

**v4 はフィールドのデフォルト nullability を nullable に反転**しており、そのまま更新すると `upsertBlog: Blog!` → `Blog`、`blogs: [Blog!]!` → `[Blog!]` のように、明示的に `nullable` を書いていない 4 フィールドの型が変わってしまう(スキーマ diff で検出)。builder に `defaultFieldNullability: false`(+ 型パラメータ `DefaultFieldNullability: false`)を明示して v3 のセマンティクスを固定した。

これ以外の API(SchemaBuilder / SimpleObjectsPlugin / queryType / simpleObject / inputType / queryFields / mutationField / toSchema)は**無修正で互換**。

## 検証

- **生成 schema.graphql が v3 ベースラインと byte 一致**(`SCHEMA IDENTICAL`)→ nitrogql / urql / frontend への波及なし
- typecheck / test(65)/ lint / format:check green
- workers-check: backend 268 KB gzip / frontend 1.85 MiB、workerd スモーク pass
- ローカル wrangler dev + D1 で認証付き実クエリを実行し、pothos 4 のリゾルバ実行を確認(`{contexts{...} blogs{...}}` → 正常応答)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK