### PR TITLE
chore(ops): backend compat date, observability, safer secret scripts

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,9 +14,9 @@
     "migrate:dev": "wrangler d1 migrations apply asa1984-blog --local",
     "migrate:prod": "wrangler d1 migrations apply asa1984-blog",
     "deploy": "wrangler deploy --var FRONTEND_URL:$FRONTEND_URL",
-    "deploy:secret": "echo \"{\\\"BACKEND_API_TOKEN\\\": \\\"$BACKEND_API_TOKEN\\\", \\\"FRONTEND_API_TOKEN\\\": \\\"$FRONTEND_API_TOKEN\\\"}\" | wrangler secret bulk",
+    "deploy:secret": "node -e 'process.stdout.write(JSON.stringify({ BACKEND_API_TOKEN: process.env.BACKEND_API_TOKEN, FRONTEND_API_TOKEN: process.env.FRONTEND_API_TOKEN }))' | wrangler secret bulk",
     "staging": "wrangler versions upload --var FRONTEND_URL:$FRONTEND_URL",
-    "staging:secret": "echo \"{\\\"BACKEND_API_TOKEN\\\": \\\"$BACKEND_API_TOKEN\\\", \\\"FRONTEND_API_TOKEN\\\": \\\"$FRONTEND_API_TOKEN\\\"}\" | wrangler versions secret bulk"
+    "staging:secret": "node -e 'process.stdout.write(JSON.stringify({ BACKEND_API_TOKEN: process.env.BACKEND_API_TOKEN, FRONTEND_API_TOKEN: process.env.FRONTEND_API_TOKEN }))' | wrangler versions secret bulk"
   },
   "dependencies": {
     "@asa1984.dev/drizzle": "workspace:*",

--- a/packages/backend/wrangler.jsonc
+++ b/packages/backend/wrangler.jsonc
@@ -1,9 +1,13 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "asa1984-api",
-  "compatibility_date": "2023-01-01",
+  "compatibility_date": "2026-08-01",
 
   "main": "src/main.ts",
+
+  "observability": {
+    "enabled": true,
+  },
 
   "r2_buckets": [
     {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,9 +13,9 @@
     "dev": "rimraf ./next && next dev",
     "build": "next build",
     "start": "opennextjs-cloudflare build && opennextjs-cloudflare populateCache local && wrangler dev --port 3000 --var BACKEND_URL:$BACKEND_URL BACKEND_API_TOKEN:$BACKEND_API_TOKEN FRONTEND_URL:$FRONTEND_URL FRONTEND_API_TOKEN:$FRONTEND_API_TOKEN",
-    "deploy:secret": "echo \"{\\\"BACKEND_API_TOKEN\\\": \\\"$BACKEND_API_TOKEN\\\", \\\"FRONTEND_API_TOKEN\\\": \\\"$FRONTEND_API_TOKEN\\\"}\" | wrangler secret bulk",
+    "deploy:secret": "node -e 'process.stdout.write(JSON.stringify({ BACKEND_API_TOKEN: process.env.BACKEND_API_TOKEN, FRONTEND_API_TOKEN: process.env.FRONTEND_API_TOKEN }))' | wrangler secret bulk",
     "staging": "opennextjs-cloudflare upload -- --var BACKEND_URL:$BACKEND_URL FRONTEND_URL:$FRONTEND_URL",
-    "staging:secret": "echo \"{\\\"BACKEND_API_TOKEN\\\": \\\"$BACKEND_API_TOKEN\\\", \\\"FRONTEND_API_TOKEN\\\": \\\"$FRONTEND_API_TOKEN\\\"}\" | wrangler versions secret bulk",
+    "staging:secret": "node -e 'process.stdout.write(JSON.stringify({ BACKEND_API_TOKEN: process.env.BACKEND_API_TOKEN, FRONTEND_API_TOKEN: process.env.FRONTEND_API_TOKEN }))' | wrangler versions secret bulk",
     "build:prod": "opennextjs-cloudflare build",
     "deploy:prod": "opennextjs-cloudflare deploy -- --var BACKEND_URL:$BACKEND_URL FRONTEND_URL:$FRONTEND_URL"
   },


### PR DESCRIPTION
Refs #35(staging リソース分離以外の運用整備 3 点)

## 変更内容

### 1. backend の compatibility_date: 2023-01-01 → 2026-08-01
3 年半分の workerd デフォルト挙動の乖離を解消。「依存追加時に突然壊れる」リスク(#35)への対処。

**検証**: 新日付でローカル D1 + wrangler dev を立ち上げ、sync CLI によるフル E2E(upsertBlog / R2 upload / delete / image list / revalidater callback)を実行して全経路の挙動一致を確認。workers-check(バンドル 268 KB / workerd スモーク)も green。

### 2. backend Worker の observability 有効化
frontend には設定済みだったが API 側が未設定で、過去の 500 もユーザー影響で初めて発覚していた。Workers Logs でリクエストログ・エラーが取れるようになる。

### 3. secrets をシェル文字列組み立てから排除
`deploy:secret` / `staging:secret`(backend/frontend 計 4 スクリプト)が `echo "{\"...\": \"$TOKEN\"}"` でシークレットをシェル展開しており、trace 出力や argv に露出しうる形だった。node がプロセス環境変数から直接 JSON を生成して `wrangler secret bulk` に stdin で渡す形に変更(値はどこにも展開されない)。ダミー値での JSON 形状検証済み。

## 検証まとめ
typecheck / lint / format:check / workers-check green、E2E は上記のとおり。**merge 後の初回デプロイで backend が新 compatibility_date で本番稼働するため、直後にサイトと API の応答確認を推奨。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK