### PR TITLE
feat: add optional date frontmatter mapped to createdAt

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -5,6 +5,7 @@ export type RemoteBlog = {
   description: string;
   content: string;
   published: boolean;
+  createdAt: string;
 };
 
 export type RemoteContext = {
@@ -13,6 +14,20 @@ export type RemoteContext = {
   emoji: string;
   content: string;
   published: boolean;
+  createdAt: string;
+};
+
+/**
+ * `createdAt` is optional: it is only sent when the frontmatter declares a
+ * `date`. Omitting it leaves the stored value alone (or lets the database
+ * default apply on insert).
+ */
+export type UpsertBlogInput = Omit<RemoteBlog, "createdAt"> & {
+  createdAt?: string;
+};
+
+export type UpsertContextInput = Omit<RemoteContext, "createdAt"> & {
+  createdAt?: string;
 };
 
 export type RemoteImage = {
@@ -61,7 +76,7 @@ export class BackendClient {
 
   async blogs(): Promise<RemoteBlog[]> {
     const data = await this.gql<{ blogs: RemoteBlog[] }>(
-      "query { blogs { slug title image description content published } }",
+      "query { blogs { slug title image description content published createdAt } }",
       {},
     );
     return data.blogs;
@@ -69,20 +84,20 @@ export class BackendClient {
 
   async contexts(): Promise<RemoteContext[]> {
     const data = await this.gql<{ contexts: RemoteContext[] }>(
-      "query { contexts { slug title emoji content published } }",
+      "query { contexts { slug title emoji content published createdAt } }",
       {},
     );
     return data.contexts;
   }
 
-  async upsertBlog(input: RemoteBlog): Promise<void> {
+  async upsertBlog(input: UpsertBlogInput): Promise<void> {
     await this.gql(
       "mutation ($input: UpsertBlogInput!) { upsertBlog(input: $input) { slug } }",
       { input },
     );
   }
 
-  async upsertContext(input: RemoteContext): Promise<void> {
+  async upsertContext(input: UpsertContextInput): Promise<void> {
     await this.gql(
       "mutation ($input: UpsertContextInput!) { upsertContext(input: $input) { slug } }",
       { input },

--- a/packages/cli/src/content.test.ts
+++ b/packages/cli/src/content.test.ts
@@ -66,6 +66,21 @@ describe("loadBlogs", () => {
     ]);
   });
 
+  it("carries the optional frontmatter date", () => {
+    const source = [
+      "---",
+      "title: Hello",
+      "image: cover.png",
+      "description: A post",
+      "published: true",
+      "date: 2024-01-15 10:30:00",
+      "---",
+      "# Body",
+    ].join("\n");
+    writePost("blog", "hello", source, ["cover.png"]);
+    expect(loadBlogs(contentDir)[0]?.date).toBe("2024-01-15 10:30:00");
+  });
+
   it("does not treat post.md as an image", () => {
     writePost("blog", "hello", blogSource(), ["cover.png"]);
     const [blog] = loadBlogs(contentDir);

--- a/packages/cli/src/frontmatter.test.ts
+++ b/packages/cli/src/frontmatter.test.ts
@@ -83,6 +83,51 @@ describe("parseBlogPost", () => {
     });
   });
 
+  it("omits date when the frontmatter does not declare one", () => {
+    const source = blogSource(
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+      ].join("\n"),
+    );
+    expect(Object.hasOwn(parseBlogPost(source).frontmatter, "date")).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ["a space separated timestamp", "2024-01-15 10:30:00"],
+    ["an ISO timestamp", "2024-01-15T10:30:00Z"],
+    ["an offset timestamp", "2024-01-15T10:30:00+09:00"],
+    ["a bare day", "2024-01-15"],
+  ])("keeps %s verbatim", (_name, date) => {
+    const source = blogSource(
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+        `date: ${date}`,
+      ].join("\n"),
+    );
+    expect(parseBlogPost(source).frontmatter.date).toBe(date);
+  });
+
+  it("strips the quotes of a quoted date", () => {
+    const source = blogSource(
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+        'date: "2024-01-15T10:30:00Z"',
+      ].join("\n"),
+    );
+    expect(parseBlogPost(source).frontmatter.date).toBe("2024-01-15T10:30:00Z");
+  });
+
   it.each([
     [
       "title is an empty string",
@@ -91,6 +136,36 @@ describe("parseBlogPost", () => {
         "image: cover.png",
         "description: A post",
         "published: true",
+      ],
+    ],
+    [
+      "date is not a parseable date",
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+        "date: yesterday",
+      ],
+    ],
+    [
+      "date is an empty string",
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+        'date: ""',
+      ],
+    ],
+    [
+      "date is not a string",
+      [
+        "title: Hello",
+        "image: cover.png",
+        "description: A post",
+        "published: true",
+        "date: true",
       ],
     ],
     [
@@ -139,8 +214,26 @@ describe("parseContextPost", () => {
     });
   });
 
+  it("parses an optional date", () => {
+    const source = blogSource(
+      [
+        "title: Hello",
+        "emoji: 🐧",
+        "published: false",
+        "date: 2024-01-15 10:30:00",
+      ].join("\n"),
+    );
+    expect(parseContextPost(source).frontmatter.date).toBe(
+      "2024-01-15 10:30:00",
+    );
+  });
+
   it.each([
     ["title is an empty string", ['title: ""', "emoji: 🐧", "published: true"]],
+    [
+      "date is not a parseable date",
+      ["title: Hello", "emoji: 🐧", "published: true", "date: nope"],
+    ],
     [
       "emoji is an empty string",
       ["title: Hello", 'emoji: ""', "published: true"],

--- a/packages/cli/src/frontmatter.ts
+++ b/packages/cli/src/frontmatter.ts
@@ -1,17 +1,35 @@
 import { parse } from "yaml";
 import { z } from "zod";
 
+/**
+ * Creation date of a post, stored verbatim as the backend's `createdAt`.
+ *
+ * The value is kept as the string the author wrote (`2024-01-15 10:30:00`,
+ * `2024-01-15T10:30:00Z`, …) instead of being reformatted, so that the
+ * frontmatter and the database hold the exact same text and the sync diff
+ * stays stable. A YAML parser that resolves timestamps to `Date` — the
+ * default schema of `yaml` does not — is normalized to an ISO string.
+ */
+const dateSchema = z
+  .union([z.string().min(1), z.date()])
+  .transform((value) => (value instanceof Date ? value.toISOString() : value))
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "date must be a parseable date",
+  });
+
 export const blogFrontmatterSchema = z.object({
   title: z.string().min(1),
   image: z.string().min(1),
   description: z.string().min(1),
   published: z.boolean(),
+  date: dateSchema.optional(),
 });
 
 export const contextFrontmatterSchema = z.object({
   title: z.string().min(1),
   emoji: z.string().min(1),
   published: z.boolean(),
+  date: dateSchema.optional(),
 });
 
 export type BlogFrontmatter = z.infer<typeof blogFrontmatterSchema>;

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,7 +3,13 @@ import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { BackendClient } from "./api";
 import { loadBlogs, loadContexts } from "./content";
-import { collectLocalImages, isEmptyPlan, planSync } from "./sync";
+import {
+  collectLocalImages,
+  isEmptyPlan,
+  planSync,
+  toUpsertBlogInput,
+  toUpsertContextInput,
+} from "./sync";
 
 const USAGE = `Usage: cli sync [options]
 
@@ -115,23 +121,10 @@ async function main() {
     );
   }
   for (const blog of plan.blogUpserts) {
-    await client.upsertBlog({
-      slug: blog.slug,
-      title: blog.title,
-      image: blog.image,
-      description: blog.description,
-      content: blog.content,
-      published: blog.published,
-    });
+    await client.upsertBlog(toUpsertBlogInput(blog));
   }
   for (const context of plan.contextUpserts) {
-    await client.upsertContext({
-      slug: context.slug,
-      title: context.title,
-      emoji: context.emoji,
-      content: context.content,
-      published: context.published,
-    });
+    await client.upsertContext(toUpsertContextInput(context));
   }
   for (const slug of plan.blogDeletes) await client.deleteBlog(slug);
   for (const slug of plan.contextDeletes) await client.deleteContext(slug);

--- a/packages/cli/src/sync.test.ts
+++ b/packages/cli/src/sync.test.ts
@@ -8,7 +8,11 @@ import {
   type LocalImage,
   planSync,
   type SyncPlan,
+  toUpsertBlogInput,
+  toUpsertContextInput,
 } from "./sync";
+
+const REMOTE_CREATED_AT = "2024-01-01 00:00:00";
 
 const localBlog = (overrides: Partial<LocalBlog> = {}): LocalBlog => ({
   slug: "hello",
@@ -29,6 +33,7 @@ const remoteBlogOf = (local: LocalBlog): RemoteBlog => ({
   description: local.description,
   published: local.published,
   content: local.content,
+  createdAt: local.date ?? REMOTE_CREATED_AT,
 });
 
 const localContext = (overrides: Partial<LocalContext> = {}): LocalContext => ({
@@ -48,6 +53,7 @@ const remoteContextOf = (local: LocalContext): RemoteContext => ({
   emoji: local.emoji,
   published: local.published,
   content: local.content,
+  createdAt: local.date ?? REMOTE_CREATED_AT,
 });
 
 const localImage = (overrides: Partial<LocalImage> = {}): LocalImage => ({
@@ -121,6 +127,30 @@ describe("planSync: blogs", () => {
     ).toEqual([]);
   });
 
+  it("upserts a blog whose date differs from the remote createdAt", () => {
+    const local = localBlog({ date: "2023-05-05 12:00:00" });
+    const remote = remoteBlogOf(localBlog({ date: REMOTE_CREATED_AT }));
+    expect(
+      plan({ localBlogs: [local], remoteBlogs: [remote] }).blogUpserts,
+    ).toEqual([local]);
+  });
+
+  it("skips a blog whose date already equals the remote createdAt", () => {
+    const local = localBlog({ date: "2023-05-05 12:00:00" });
+    expect(
+      plan({ localBlogs: [local], remoteBlogs: [remoteBlogOf(local)] })
+        .blogUpserts,
+    ).toEqual([]);
+  });
+
+  it("ignores the remote createdAt when the frontmatter has no date", () => {
+    const local = localBlog();
+    const remote = remoteBlogOf(localBlog({ date: "1999-12-31 23:59:59" }));
+    expect(
+      plan({ localBlogs: [local], remoteBlogs: [remote] }).blogUpserts,
+    ).toEqual([]);
+  });
+
   it("deletes a blog that only exists remotely", () => {
     const local = localBlog();
     const orphan = remoteBlogOf(localBlog({ slug: "gone" }));
@@ -163,6 +193,32 @@ describe("planSync: contexts", () => {
       ).toEqual([local]);
     },
   );
+
+  it("upserts a context whose date differs from the remote createdAt", () => {
+    const local = localContext({ date: "2023-05-05 12:00:00" });
+    const remote = remoteContextOf(localContext({ date: REMOTE_CREATED_AT }));
+    expect(
+      plan({ localContexts: [local], remoteContexts: [remote] }).contextUpserts,
+    ).toEqual([local]);
+  });
+
+  it("skips a context whose date already equals the remote createdAt", () => {
+    const local = localContext({ date: "2023-05-05 12:00:00" });
+    expect(
+      plan({ localContexts: [local], remoteContexts: [remoteContextOf(local)] })
+        .contextUpserts,
+    ).toEqual([]);
+  });
+
+  it("ignores the remote createdAt when the frontmatter has no date", () => {
+    const local = localContext();
+    const remote = remoteContextOf(
+      localContext({ date: "1999-12-31 23:59:59" }),
+    );
+    expect(
+      plan({ localContexts: [local], remoteContexts: [remote] }).contextUpserts,
+    ).toEqual([]);
+  });
 
   it("deletes a context that only exists remotely", () => {
     const orphan = remoteContextOf(localContext({ slug: "gone" }));
@@ -281,6 +337,59 @@ describe("collectLocalImages", () => {
 
   it("returns nothing when no post has an image", () => {
     expect(collectLocalImages([], [], () => "md5")).toEqual([]);
+  });
+});
+
+describe("toUpsertBlogInput", () => {
+  it("sends the frontmatter date as createdAt", () => {
+    expect(
+      toUpsertBlogInput(localBlog({ date: "2023-05-05 12:00:00" })),
+    ).toEqual({
+      slug: "hello",
+      title: "Hello",
+      image: "cover.png",
+      description: "A post",
+      content: "# Body",
+      published: true,
+      createdAt: "2023-05-05 12:00:00",
+    });
+  });
+
+  it("omits createdAt entirely when the frontmatter has no date", () => {
+    const input = toUpsertBlogInput(localBlog());
+    expect(Object.hasOwn(input, "createdAt")).toBe(false);
+  });
+
+  it("drops the local-only fields the backend does not accept", () => {
+    const input = toUpsertBlogInput(localBlog());
+    expect(Object.hasOwn(input, "dir")).toBe(false);
+    expect(Object.hasOwn(input, "images")).toBe(false);
+  });
+});
+
+describe("toUpsertContextInput", () => {
+  it("sends the frontmatter date as createdAt", () => {
+    expect(
+      toUpsertContextInput(localContext({ date: "2023-05-05 12:00:00" })),
+    ).toEqual({
+      slug: "nix",
+      title: "Nix",
+      emoji: "❄️",
+      content: "# Body",
+      published: true,
+      createdAt: "2023-05-05 12:00:00",
+    });
+  });
+
+  it("omits createdAt entirely when the frontmatter has no date", () => {
+    const input = toUpsertContextInput(localContext());
+    expect(Object.hasOwn(input, "createdAt")).toBe(false);
+  });
+
+  it("drops the local-only fields the backend does not accept", () => {
+    const input = toUpsertContextInput(localContext());
+    expect(Object.hasOwn(input, "dir")).toBe(false);
+    expect(Object.hasOwn(input, "images")).toBe(false);
   });
 });
 

--- a/packages/cli/src/sync.ts
+++ b/packages/cli/src/sync.ts
@@ -1,4 +1,10 @@
-import type { RemoteBlog, RemoteContext, RemoteImage } from "./api";
+import type {
+  RemoteBlog,
+  RemoteContext,
+  RemoteImage,
+  UpsertBlogInput,
+  UpsertContextInput,
+} from "./api";
 import type { LocalBlog, LocalContext } from "./content";
 import { imageKey } from "./image-key";
 
@@ -28,18 +34,48 @@ export const isEmptyPlan = (plan: SyncPlan): boolean =>
   plan.imageUploads.length === 0 &&
   plan.imageDeletes.length === 0;
 
+// A post without a `date` in its frontmatter leaves createdAt to the backend,
+// so the remote value must not be treated as a difference.
+const createdAtChanged = (
+  local: { date?: string },
+  remote: { createdAt: string },
+): boolean => local.date !== undefined && local.date !== remote.createdAt;
+
 const blogChanged = (local: LocalBlog, remote: RemoteBlog): boolean =>
   local.title !== remote.title ||
   local.image !== remote.image ||
   local.description !== remote.description ||
   local.published !== remote.published ||
-  local.content !== remote.content;
+  local.content !== remote.content ||
+  createdAtChanged(local, remote);
 
 const contextChanged = (local: LocalContext, remote: RemoteContext): boolean =>
   local.title !== remote.title ||
   local.emoji !== remote.emoji ||
   local.published !== remote.published ||
-  local.content !== remote.content;
+  local.content !== remote.content ||
+  createdAtChanged(local, remote);
+
+export const toUpsertBlogInput = (local: LocalBlog): UpsertBlogInput => ({
+  slug: local.slug,
+  title: local.title,
+  image: local.image,
+  description: local.description,
+  content: local.content,
+  published: local.published,
+  ...(local.date === undefined ? {} : { createdAt: local.date }),
+});
+
+export const toUpsertContextInput = (
+  local: LocalContext,
+): UpsertContextInput => ({
+  slug: local.slug,
+  title: local.title,
+  emoji: local.emoji,
+  content: local.content,
+  published: local.published,
+  ...(local.date === undefined ? {} : { createdAt: local.date }),
+});
 
 export function collectLocalImages(
   blogs: LocalBlog[],

--- a/packages/graphql/src/graphql/blog.ts
+++ b/packages/graphql/src/graphql/blog.ts
@@ -55,6 +55,9 @@ const UpsertBlogInput = builder.inputType("UpsertBlogInput", {
     description: t.string({ required: true }),
     content: t.string({ required: true }),
     published: t.boolean({ required: true }),
+    // The content repository is the source of truth for the creation date, so
+    // when it is given it wins over whatever the database holds.
+    createdAt: t.string({ required: false }),
   }),
 });
 
@@ -69,7 +72,9 @@ builder.mutationField("upsertBlog", (t) =>
       }),
     },
     resolve: async (_root, { input }, context) => {
-      const { slug } = input;
+      const { slug, createdAt, ...fields } = input;
+      // Spreading an absent createdAt would overwrite the column with NULL.
+      const createdAtField = createdAt == null ? {} : { createdAt };
 
       const db = drizzle(context.DB, { schema });
       const oldOne = await db.query.blogs.findFirst({
@@ -83,7 +88,9 @@ builder.mutationField("upsertBlog", (t) =>
           .update(blogsSchema)
           .set({
             updatedAt: CURRENT_TIMESTAMP(),
-            ...input,
+            slug,
+            ...fields,
+            ...createdAtField,
           })
           .where(eq(blogsSchema.slug, slug))
           .returning();
@@ -99,7 +106,9 @@ builder.mutationField("upsertBlog", (t) =>
         .insert(blogsSchema)
         .values({
           id,
-          ...input,
+          slug,
+          ...fields,
+          ...createdAtField,
         })
         .returning();
 

--- a/packages/graphql/src/graphql/context.ts
+++ b/packages/graphql/src/graphql/context.ts
@@ -56,6 +56,9 @@ const UpsertContextInput = builder.inputType("UpsertContextInput", {
     emoji: t.string({ required: true }),
     content: t.string({ required: true }),
     published: t.boolean({ required: true }),
+    // The content repository is the source of truth for the creation date, so
+    // when it is given it wins over whatever the database holds.
+    createdAt: t.string({ required: false }),
   }),
 });
 
@@ -70,7 +73,9 @@ builder.mutationField("upsertContext", (t) =>
       }),
     },
     resolve: async (_parent, { input }, context) => {
-      const { slug } = input;
+      const { slug, createdAt, ...fields } = input;
+      // Spreading an absent createdAt would overwrite the column with NULL.
+      const createdAtField = createdAt == null ? {} : { createdAt };
       const db = drizzle(context.DB, { schema });
 
       const { revalidater } = context;
@@ -84,7 +89,9 @@ builder.mutationField("upsertContext", (t) =>
           .update(contextsSchema)
           .set({
             updatedAt: CURRENT_TIMESTAMP(),
-            ...input,
+            slug,
+            ...fields,
+            ...createdAtField,
           })
           .where(eq(contextsSchema.slug, slug))
           .returning();
@@ -100,7 +107,9 @@ builder.mutationField("upsertContext", (t) =>
         .insert(contextsSchema)
         .values({
           id,
-          ...input,
+          slug,
+          ...fields,
+          ...createdAtField,
         })
         .returning();
 


### PR DESCRIPTION
frontmatter に optional な `date` フィールドを追加し、記事の作成日時 (`createdAt`) を git 管理下に置けるようにする。

`Refs #46`(コンテンツリポジトリ側のバックフィルが残っているため close しない)

## 変更内容

### graphql

- `UpsertBlogInput` / `UpsertContextInput` に `createdAt: String`(optional)を追加。
- 渡された場合は **insert / update の双方**で `created_at` に反映する。git を正本とするため、update でも既存値を上書きする。
- 渡されなかった場合は現行どおり。insert はスキーマのデフォルト、update は不変。
- resolver では `const { slug, createdAt, ...fields } = input` と分解し、`createdAt` が `null` / `undefined` のときは spread しない。`...input` をそのまま drizzle の `set` / `values` に渡すと、未指定の `createdAt` が NULL 上書きになるため。

### cli

- frontmatter スキーマ(blog / context 共通)に `date` を optional で追加。
- sync は remote の `blogs` / `contexts` クエリで `createdAt` も取得する。local に `date` がある場合のみ差分比較に含め、upsert 時に `createdAt` として送る。`date` が無い記事は比較にも送信にも一切関与せず、挙動は従来と同じ。
- `main.ts` にインラインで書かれていた upsert input の組み立てを `toUpsertBlogInput` / `toUpsertContextInput` として `sync.ts` に切り出した(テスト可能にするため)。

## `date` の正規化方針

**著者が書いた文字列をそのまま `createdAt` に格納する。フォーマットの変換はしない。**

- `yaml` パッケージのデフォルトスキーマ(YAML 1.2 core)はタイムスタンプを解決しないため、`date: 2024-01-15 10:30:00` も `date: "2024-01-15T10:30:00Z"` も文字列として得られる。これを検証済み。
- 将来 YAML 側が `Date` を返すようになった場合に備え、zod では `z.union([z.string().min(1), z.date()])` を受けて `Date` のみ `toISOString()` で正規化する。
- 「そのまま格納」を選んだ理由は差分判定の安定性。CLI は local の `date` と remote の `createdAt` を **文字列として比較**するので、格納時に整形すると毎回差分が出て upsert が止まらなくなる。
- 唯一のバリデーションとして `Date.parse` が通ることだけを要求する。`date: yesterday` のようなタイプミスがそのまま DB に入り、frontend の `new Date(blog.createdAt)` が Invalid Date になるのを防ぐため。

## テスト

CLI のテストを 65 → 89 に追加。

- frontmatter: `date` あり / なし、スペース区切り・ISO・オフセット付き・日付のみの各表記が verbatim に保たれること、クォート付きの剥がれ方、パースできない値・空文字・非文字列の拒否。
- content: `date` が `LocalBlog` まで伝搬すること。
- sync: 「`date` だけ変わった → upsert」「`date` が remote の `createdAt` と一致 → skip」「`date` 未指定なら remote の `createdAt` の差分を無視」を blog / context 双方。
- `toUpsertBlogInput` / `toUpsertContextInput`: `date` を `createdAt` として送ること、未指定なら **キー自体を生やさない**こと。

## 検証

`typecheck` / `test` / `lint` / `format:check` / `ALLOW_EMPTY_CONTENT=1 build` すべて green。

加えて `wrangler dev` + ローカル D1 で実挙動を確認した。

| ケース | 結果 |
| --- | --- |
| `createdAt` 付き insert | 指定値が格納される |
| `createdAt` 無しで update | 既存値が保持される(NULL にならない) |
| 別の `createdAt` で update | 上書きされる |
| `createdAt: null` で update | 未指定と同じ扱いで既存値が保持される |
| `createdAt` 無しで insert | スキーマデフォルトが入る |
| ISO 文字列 | 整形されずそのまま往復する |
| context の insert / update | blog と同じ挙動 |

frontend の `.graphql` クエリは既に `createdAt` を取得しているため変更なし。DB マイグレーションも不要(既存カラムを使うだけ)。

## 後続作業(このPRのスコープ外)

コンテンツリポジトリの既存記事に `date` を書き戻すバックフィル。

その際 **`date` には現在の D1 の `createdAt` の値をそのままコピーすること**。`CURRENT_TIMESTAMP` は `new Date().toISOString()` なので、既存レコードはミリ秒付きの ISO 文字列(`2024-01-15T10:30:00.000Z`)である点に注意(issue 本文の `YYYY-MM-DD HH:MM:SS` という記述は実装と食い違っている)。表記を変えても初回 sync で収束はするが、その一回だけ全記事が無駄に upsert される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
