### PR TITLE
feat(markdown): add Zenn-style inline footnotes

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,7 +17,8 @@
     "staging": "opennextjs-cloudflare upload -- --var BACKEND_URL:$BACKEND_URL FRONTEND_URL:$FRONTEND_URL",
     "staging:secret": "echo \"{\\\"BACKEND_API_TOKEN\\\": \\\"$BACKEND_API_TOKEN\\\", \\\"FRONTEND_API_TOKEN\\\": \\\"$FRONTEND_API_TOKEN\\\"}\" | wrangler versions secret bulk",
     "build:prod": "opennextjs-cloudflare build",
-    "deploy:prod": "opennextjs-cloudflare deploy -- --var BACKEND_URL:$BACKEND_URL FRONTEND_URL:$FRONTEND_URL"
+    "deploy:prod": "opennextjs-cloudflare deploy -- --var BACKEND_URL:$BACKEND_URL FRONTEND_URL:$FRONTEND_URL",
+    "test": "vitest run"
   },
   "dependencies": {
     "@asa1984.dev/backend": "workspace:*",
@@ -66,9 +67,11 @@
     "@types/unist": "3.0.3",
     "chokidar-cli": "catalog:",
     "graphql": "catalog:",
+    "remark-parse": "11.0.0",
     "rimraf": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "wrangler": "catalog:"
   }
 }

--- a/packages/frontend/src/features/markdown/compile_mdx.ts
+++ b/packages/frontend/src/features/markdown/compile_mdx.ts
@@ -11,6 +11,7 @@ import { create_custom_components } from "./custom_components";
 import { get_highlighter } from "./highlighter";
 import {
   linkcard_handler,
+  remark_inline_footnote,
   remark_linkcard,
   remark_zenn_message,
   // zenn_message_handler,
@@ -36,6 +37,7 @@ export async function compile_mdx({
       mdxOptions: {
         remarkPlugins: [
           remark_zenn_message,
+          remark_inline_footnote,
           remark_comment,
           remark_gfm,
           remark_gemoji,

--- a/packages/frontend/src/features/markdown/lib/index.ts
+++ b/packages/frontend/src/features/markdown/lib/index.ts
@@ -1,2 +1,3 @@
+export * from "./remark_inline_footnote";
 export * from "./remark_linkcard";
 export * from "./remark_zenn_message";

--- a/packages/frontend/src/features/markdown/lib/remark_inline_footnote.test.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_inline_footnote.test.ts
@@ -1,0 +1,155 @@
+import type { FootnoteDefinition, FootnoteReference, Root } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { remark_inline_footnote } from "./remark_inline_footnote";
+
+const parse = (markdown: string): Root => {
+  const processor = unified().use(remarkParse).use(remarkGfm);
+  const tree = processor.parse(markdown);
+  remark_inline_footnote()(tree, undefined as never, undefined as never);
+  return tree as Root;
+};
+
+const collect = <T extends { type: string }>(
+  root: Root,
+  type: T["type"],
+): T[] => {
+  const found: T[] = [];
+  const walk = (node: { type: string; children?: { type: string }[] }) => {
+    if (node.type === type) found.push(node as unknown as T);
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(root);
+  return found;
+};
+
+const references = (root: Root) =>
+  collect<FootnoteReference>(root, "footnoteReference");
+const definitions = (root: Root) =>
+  collect<FootnoteDefinition>(root, "footnoteDefinition");
+
+describe("remark_inline_footnote", () => {
+  it("converts ^[...] into a footnote reference and definition", () => {
+    const tree = parse("本文^[これが脚注]の続き。");
+
+    const refs = references(tree);
+    const defs = definitions(tree);
+    expect(refs).toHaveLength(1);
+    expect(defs).toHaveLength(1);
+    expect(refs[0]?.identifier).toBe(defs[0]?.identifier);
+    expect(defs[0]?.children).toEqual([
+      { type: "paragraph", children: [{ type: "text", value: "これが脚注" }] },
+    ]);
+  });
+
+  it("keeps the surrounding text intact", () => {
+    const tree = parse("本文^[脚注]の続き。");
+
+    const paragraph = tree.children[0];
+    if (paragraph?.type !== "paragraph") throw new Error("expected paragraph");
+    expect(paragraph.children).toEqual([
+      { type: "text", value: "本文" },
+      expect.objectContaining({ type: "footnoteReference" }),
+      { type: "text", value: "の続き。" },
+    ]);
+  });
+
+  it("handles a footnote at the start and end of a text node", () => {
+    const start = parse("^[先頭]です。");
+    const startParagraph = start.children[0];
+    if (startParagraph?.type !== "paragraph")
+      throw new Error("expected paragraph");
+    expect(startParagraph.children[0]?.type).toBe("footnoteReference");
+
+    const end = parse("これは^[末尾]");
+    const endParagraph = end.children[0];
+    if (endParagraph?.type !== "paragraph")
+      throw new Error("expected paragraph");
+    expect(endParagraph.children.at(-1)?.type).toBe("footnoteReference");
+  });
+
+  it("numbers multiple footnotes uniquely in document order", () => {
+    const tree = parse("一つ目^[注1]と二つ目^[注2]。\n\n三つ目^[注3]。");
+
+    const refs = references(tree);
+    const defs = definitions(tree);
+    expect(refs).toHaveLength(3);
+    expect(defs).toHaveLength(3);
+    expect(refs.map((r) => r.identifier)).toEqual(
+      defs.map((d) => d.identifier),
+    );
+    expect(new Set(refs.map((r) => r.identifier)).size).toBe(3);
+  });
+
+  it("converts multiple footnotes inside a single text node", () => {
+    const tree = parse("A^[one]B^[two]C");
+
+    const paragraph = tree.children[0];
+    if (paragraph?.type !== "paragraph") throw new Error("expected paragraph");
+    expect(paragraph.children.map((c) => c.type)).toEqual([
+      "text",
+      "footnoteReference",
+      "text",
+      "footnoteReference",
+      "text",
+    ]);
+  });
+
+  it("works inside emphasis", () => {
+    const tree = parse("*強調^[注釈]文*");
+
+    expect(references(tree)).toHaveLength(1);
+    expect(definitions(tree)).toHaveLength(1);
+  });
+
+  it("leaves markdown without inline footnotes untouched", () => {
+    const markdown = "ただの[リンク](https://example.com)と ^ と [括弧] です。";
+    const tree = parse(markdown);
+    const untouched = unified().use(remarkParse).use(remarkGfm).parse(markdown);
+
+    expect(tree).toEqual(untouched);
+  });
+
+  it("ignores empty footnotes", () => {
+    const tree = parse("空^[]です。");
+
+    expect(references(tree)).toHaveLength(0);
+    expect(definitions(tree)).toHaveLength(0);
+  });
+
+  it("does not clash with handwritten GFM footnotes", () => {
+    const tree = parse(
+      "参照形式[^a]とインライン^[インライン注]。\n\n[^a]: 手書きの定義",
+    );
+
+    const refs = references(tree);
+    const defs = definitions(tree);
+    expect(refs).toHaveLength(2);
+    expect(defs).toHaveLength(2);
+    const identifiers = [...refs, ...defs].map((n) => n.identifier);
+    expect(new Set(identifiers).size).toBe(2);
+    // The handwritten identifier survives as-is.
+    expect(identifiers).toContain("a");
+  });
+
+  it("does not span across newlines", () => {
+    const tree = parse("これは^[改行\nを含む]テキスト。");
+
+    expect(references(tree)).toHaveLength(0);
+  });
+
+  it("renders through the existing GFM footnote pipeline (mdast → hast)", async () => {
+    const { toHast } = await import("mdast-util-to-hast");
+    const tree = parse("本文^[インライン注釈]です。");
+
+    const hast = JSON.stringify(
+      toHast(tree, { footnoteLabel: "脚注", footnoteLabelTagName: "span" }),
+    );
+    // A superscript reference link and the footnote section content.
+    expect(hast).toContain('"tagName":"sup"');
+    expect(hast).toContain("インライン注釈");
+    expect(hast).toContain("脚注");
+  });
+});

--- a/packages/frontend/src/features/markdown/lib/remark_inline_footnote.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_inline_footnote.ts
@@ -1,0 +1,58 @@
+import type { FootnoteDefinition, PhrasingContent, Root, Text } from "mdast";
+import type { Transformer } from "unified";
+import { visit } from "unist-util-visit";
+
+// Zenn-compatible inline footnotes: ^[note] inside prose. The note body is
+// plain text only (no "]" and no newline) — richer content should use the
+// GFM reference form ([^id] + definition), which this plugin coexists with.
+const INLINE_FOOTNOTE = /\^\[([^\]\n]+)\]/g;
+
+// Namespaced so generated identifiers cannot collide with handwritten
+// GFM footnote identifiers.
+const ID_PREFIX = "inline-fn-";
+
+export const remark_inline_footnote = (): Transformer<Root> => {
+  return (tree) => {
+    const definitions: FootnoteDefinition[] = [];
+
+    visit(tree, "text", (node: Text, index, parent) => {
+      if (!parent || index === undefined) return;
+
+      const matches = [...node.value.matchAll(INLINE_FOOTNOTE)];
+      if (matches.length === 0) return;
+
+      const parts: PhrasingContent[] = [];
+      let consumed = 0;
+      for (const match of matches) {
+        if (match.index > consumed) {
+          parts.push({
+            type: "text",
+            value: node.value.slice(consumed, match.index),
+          });
+        }
+        const identifier = `${ID_PREFIX}${definitions.length + 1}`;
+        definitions.push({
+          type: "footnoteDefinition",
+          identifier,
+          children: [
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: match[1]! }],
+            },
+          ],
+        });
+        parts.push({ type: "footnoteReference", identifier });
+        consumed = match.index + match[0].length;
+      }
+      if (consumed < node.value.length) {
+        parts.push({ type: "text", value: node.value.slice(consumed) });
+      }
+
+      parent.children.splice(index, 1, ...parts);
+      // Resume after the nodes we just inserted.
+      return index + parts.length;
+    });
+
+    tree.children.push(...definitions);
+  };
+};

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       graphql:
         specifier: 'catalog:'
         version: 16.14.0
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -344,6 +347,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.16.9)(tsx@4.23.12)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
         version: 4.121.0(@cloudflare/workers-types@5.20260812.1)


### PR DESCRIPTION
Closes #59

## 内容

Zenn 互換のインライン脚注記法 `^[注釈]` を追加。text ノード中の `^[...]` を mdast の `footnoteReference` + 自動採番の `footnoteDefinition`(識別子は `inline-fn-` プレフィックスで手書き GFM 脚注と衝突しない)に変換し、**既存の GFM 脚注パイプライン(remark-rehype + `footnoteLabel: "脚注"`)にそのまま合流**させる。表示側の変更はゼロで、参照形式 `[^id]` と混在しても番号・脚注セクションが一貫する。

## TDD

**テストを先に書いて red を確認 → 実装 → green** の順で進めた(コミットは 1 つだが、red 時点の失敗と green の 11 pass を作業ログで確認済み)。

frontend パッケージに vitest を導入(catalog 参照。#28 で「markdown 変換系」とされていた領域の第一号)。テスト 11 ケース:

- 基本変換(reference/definition の対応・本文テキストの保存)
- 位置バリエーション(先頭・末尾・1 テキストノード内に複数・強調内)
- 文書全体での一意な採番と出現順
- 非変換系(脚注なしの木が **byte 単位で不変**・空 `^[]`・改行跨ぎ)
- 手書き GFM 脚注との共存(識別子衝突なし)
- mdast → hast の統合(sup 参照リンクと「脚注」セクションの生成)

## v1 の記法仕様(issue 記載どおり)

- 注釈内容はプレーンテキストのみ(`]` / 改行不可)。リッチな内容は従来の参照形式で
- `\^[...]` エスケープは CommonMark 仕様上 AST で区別不能のため未対応(literal はコードスパンで)

## 検証

test(frontend 11 + cli 89)/ typecheck / lint / format:check / `ALLOW_EMPTY_CONTENT=1 build` すべて green。

補足: 実記事での見た目確認は、merge 後にコンテンツリポジトリのテスト記事(または既存記事への試し書き)で行うのが確実です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK