### PR TITLE
chore(deps): update nitrogql to 2.0.0 stable

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -58,8 +58,8 @@
   "devDependencies": {
     "@asa1984.dev/tsconfig": "workspace:*",
     "@graphql-typed-document-node/core": "3.2.0",
-    "@nitrogql/cli": "1.6.0-beta.1",
-    "@nitrogql/graphql-loader": "1.6.0-beta.1",
+    "@nitrogql/cli": "2.0.0",
+    "@nitrogql/graphql-loader": "2.0.0",
     "@opennextjs/cloudflare": "1.20.2",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,11 +309,11 @@ importers:
         specifier: 3.2.0
         version: 3.2.0(graphql@16.14.0)
       '@nitrogql/cli':
-        specifier: 1.6.0-beta.1
-        version: 1.6.0-beta.1(graphql@16.14.0)
+        specifier: 2.0.0
+        version: 2.0.0(graphql@16.14.0)
       '@nitrogql/graphql-loader':
-        specifier: 1.6.0-beta.1
-        version: 1.6.0-beta.1(graphql@16.14.0)
+        specifier: 2.0.0
+        version: 2.0.0(graphql@16.14.0)
       '@opennextjs/cloudflare':
         specifier: 1.20.2
         version: 1.20.2(next@15.5.22(@types/node@22.19.19)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(wrangler@4.121.0(@cloudflare/workers-types@5.20260812.1))
@@ -1676,29 +1676,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@nitrogql/cli@1.6.0-beta.1':
-    resolution: {integrity: sha512-1JvP0aLpexirMsPigtwkPzjzENKAy/v96Tzr4lzQHRh16PeVdTAW6t7JhXnTVayWBg3frZf8VgHcYk88F0Xn/A==}
+  '@nitrogql/cli@2.0.0':
+    resolution: {integrity: sha512-5d0KorErZLhMh4QBAm17WZM4vPP+PC4N5wr3jKTKEAK+Tx9lss5q2DcVnyr4IFbz5yFVInLec3bf3LMnYKpMUw==}
+    engines: {node: '>=22'}
     hasBin: true
 
-  '@nitrogql/core@1.6.0-beta.1':
-    resolution: {integrity: sha512-FjKfUczTWUOk74jr5fJkLP2uaLvHJKcC1EKmYC4fLLdTGOIMANUiR8aqTBbUkWWa5pFHkqJw2dsI0gs/DwT1/A==}
+  '@nitrogql/core@2.0.0':
+    resolution: {integrity: sha512-75X3W37iwl1GczvKcV3GlRFsLffQOHzsw56Cw4HA/ZFV/mGCKMGI3MjPYJbOQ5sGNkpY/4TldJrZ73Om0rlLtg==}
+    engines: {node: '>=22'}
     peerDependencies:
       graphql: ^16.0.0 || ^17.0.0
     peerDependenciesMeta:
       graphql:
         optional: true
 
-  '@nitrogql/esbuild-register@1.6.0-beta.1':
-    resolution: {integrity: sha512-mlhh81l2QVaoydbxbDsyHwBnNrublUyPWJZoz2T5MVINdXnuteRCxsreV/ISoa3irvMlMIPSl7yZCf+Lc12DtQ==}
+  '@nitrogql/esbuild-register@2.0.0':
+    resolution: {integrity: sha512-AfI1k8TuEUcQaJ/s4Vfu3w4wrmUvU/5RkLBNV0TSvg3bLkbBPVmLpli8J9PFhsldJu7uXblvfRPQ0WKkKeYhug==}
+    engines: {node: '>=22'}
 
-  '@nitrogql/graphql-loader@1.6.0-beta.1':
-    resolution: {integrity: sha512-PEDbIsfxqf7e/Yvxk6Y9zTdRH/slRqsnrOmWiJkgHbAwZ5jOFC4tyGW3Qaz8myvMs624ZenOQgktLj0mxr6Psg==}
+  '@nitrogql/graphql-loader@2.0.0':
+    resolution: {integrity: sha512-/ZdW6G+McrQaTtBNq4JR6Gt64q8ZpkM2q6SGWnzWAcGVpXEqSZzkZnUtV2KsUx44fFPrHF53T8MRdEyJpol2Hw==}
+    engines: {node: '>=22'}
 
-  '@nitrogql/loader-core@1.6.0-beta.1':
-    resolution: {integrity: sha512-OUOAdLRsbfLjYAyQGfPZEQ6mDDZaDXxfmhhya9PdYhwy2sAbL0v01FSNKQRdWa29R7Q3wtnA/yd0otAFM8CufA==}
+  '@nitrogql/loader-core@2.0.0':
+    resolution: {integrity: sha512-NRCDuH8mvIGcgnKRyPtUVtS6lwVhB+FJ05uHnmMfsyPONlkp4IfL/73UU92VI6FmKLi+NMJlm92PzpXViby9/w==}
+    engines: {node: '>=22'}
 
-  '@nitrogql/wasi-preview1@1.6.0-beta.1':
-    resolution: {integrity: sha512-FCZjXs79+mhqxrUbmo9S1x20rWezOuS7vvefB3UIZwlJt2FZg5VW8Hle7l6Asu64kViL0iW4xaJZdXTMBkVEzw==}
+  '@nitrogql/wasi-preview1@2.0.0':
+    resolution: {integrity: sha512-dDR2I9WnKvKUlZtjAXuwJ0hgqsbR4eSFOAVgme4NQjOZof1P36Km12cM+sNHgdTtZ9Riv+IYFAK9I9XaCH0PuA==}
+    engines: {node: '>=22'}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -6249,36 +6255,36 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.22':
     optional: true
 
-  '@nitrogql/cli@1.6.0-beta.1(graphql@16.14.0)':
+  '@nitrogql/cli@2.0.0(graphql@16.14.0)':
     dependencies:
-      '@nitrogql/core': 1.6.0-beta.1(graphql@16.14.0)
-      '@nitrogql/wasi-preview1': 1.6.0-beta.1
+      '@nitrogql/core': 2.0.0(graphql@16.14.0)
+      '@nitrogql/wasi-preview1': 2.0.0
     transitivePeerDependencies:
       - graphql
 
-  '@nitrogql/core@1.6.0-beta.1(graphql@16.14.0)':
+  '@nitrogql/core@2.0.0(graphql@16.14.0)':
     dependencies:
-      '@nitrogql/esbuild-register': 1.6.0-beta.1
+      '@nitrogql/esbuild-register': 2.0.0
       esbuild: 0.25.12
     optionalDependencies:
       graphql: 16.14.0
 
-  '@nitrogql/esbuild-register@1.6.0-beta.1':
+  '@nitrogql/esbuild-register@2.0.0':
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       jsonc-parser: 3.3.1
       pirates: 4.0.7
 
-  '@nitrogql/graphql-loader@1.6.0-beta.1(graphql@16.14.0)':
+  '@nitrogql/graphql-loader@2.0.0(graphql@16.14.0)':
     dependencies:
-      '@nitrogql/core': 1.6.0-beta.1(graphql@16.14.0)
-      '@nitrogql/loader-core': 1.6.0-beta.1
+      '@nitrogql/core': 2.0.0(graphql@16.14.0)
+      '@nitrogql/loader-core': 2.0.0
     transitivePeerDependencies:
       - graphql
 
-  '@nitrogql/loader-core@1.6.0-beta.1': {}
+  '@nitrogql/loader-core@2.0.0': {}
 
-  '@nitrogql/wasi-preview1@1.6.0-beta.1': {}
+  '@nitrogql/wasi-preview1@2.0.0': {}
 
   '@noble/ciphers@1.3.0': {}
 


### PR DESCRIPTION
## 概要

#34 の残束「nitrogql beta 脱出」。@nitrogql/cli / @nitrogql/graphql-loader を 1.6.0-beta.1 → 2.0.0(exact 固定)。

## codegen 差分

- 生成型が namespace 構造(`__OperationInput/Output`, `__ResolverInput/Output`)に再編。入力方向の `ID` が `string | number` になる等、方向別の型が正確になった
- トップレベルの `Blog` / `Query` 等の alias は維持されるため、消費側コードは無変更
- schema SDL 出力に `directive @oneOf` が追記(graphql 16.10+ 対応)

## 検証

- typecheck / test / `ALLOW_EMPTY_CONTENT=1 pnpm run build`(webpack の @nitrogql/graphql-loader 経路を通過)全て緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK