### PR TITLE
test(frontend): cover blog/context fetch layer

### DIFF
--- a/packages/frontend/src/features/blog/fetch.test.ts
+++ b/packages/frontend/src/features/blog/fetch.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get_post, get_posts_date_sorted, get_published_posts } from "./fetch";
+
+const query = vi.fn();
+
+vi.mock("@/libs/graphql", () => ({
+  client: { query: (...args: unknown[]) => query(...args) },
+}));
+vi.mock("./getBlogs.graphql", () => ({ default: "GetBlogs" }));
+vi.mock("./getBlogBySlug.graphql", () => ({ default: "GetBlogBySlug" }));
+
+const blog = (overrides: Record<string, unknown> = {}) => ({
+  slug: "first",
+  title: "タイトル",
+  description: "説明",
+  image: "cover.webp",
+  content: "本文",
+  published: true,
+  createdAt: "2023-10-23T00:00:00.000Z",
+  updatedAt: "2023-10-23T00:00:00.000Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.stubEnv("BACKEND_URL", "http://backend.test");
+  vi.stubEnv("ALLOW_EMPTY_CONTENT", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  query.mockReset();
+});
+
+describe("get_published_posts", () => {
+  it("published: false の記事を除外する", async () => {
+    query.mockResolvedValue({
+      data: {
+        blogs: [
+          blog({ slug: "public" }),
+          blog({ slug: "draft", published: false }),
+        ],
+      },
+    });
+
+    const posts = await get_published_posts();
+
+    expect(posts.map((p) => p.slug)).toEqual(["public"]);
+  });
+
+  it("画像 URL を BACKEND_URL と sha256 キーから組み立てる", async () => {
+    query.mockResolvedValue({ data: { blogs: [blog()] } });
+
+    const [post] = await get_published_posts();
+
+    // sha256("blog/first/cover.webp")
+    const hash = Buffer.from(
+      await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode("blog/first/cover.webp"),
+      ),
+    ).toString("hex");
+    expect(post?.meta.image).toBe(`http://backend.test/image/delivery/${hash}`);
+  });
+
+  it("フェッチ失敗時はビルドを落とす (throw)", async () => {
+    query.mockResolvedValue({
+      data: undefined,
+      error: { message: "boom" },
+    });
+
+    await expect(get_published_posts()).rejects.toThrow(
+      "Failed to fetch blogs: boom",
+    );
+  });
+
+  it("ALLOW_EMPTY_CONTENT=1 のときは空配列で継続する", async () => {
+    vi.stubEnv("ALLOW_EMPTY_CONTENT", "1");
+    query.mockResolvedValue({ data: undefined, error: { message: "boom" } });
+
+    await expect(get_published_posts()).resolves.toEqual([]);
+  });
+});
+
+describe("get_posts_date_sorted", () => {
+  it("新しい記事から順に並べる", async () => {
+    query.mockResolvedValue({
+      data: {
+        blogs: [
+          blog({ slug: "old", createdAt: "2022-11-15T15:00:00.000Z" }),
+          blog({ slug: "new", createdAt: "2024-03-08T11:39:03.680Z" }),
+          blog({ slug: "mid", createdAt: "2023-10-23T00:00:00.000Z" }),
+        ],
+      },
+    });
+
+    const posts = await get_posts_date_sorted();
+
+    expect(posts.map((p) => p.slug)).toEqual(["new", "mid", "old"]);
+  });
+});
+
+describe("get_post", () => {
+  it("存在しない slug は null を返す", async () => {
+    query.mockResolvedValue({ data: { blog: null } });
+
+    await expect(get_post("missing")).resolves.toBeNull();
+  });
+
+  it("記事をメタデータ付きで返す", async () => {
+    query.mockResolvedValue({ data: { blog: blog() } });
+
+    const post = await get_post("first");
+
+    expect(post).toMatchObject({
+      slug: "first",
+      content: "本文",
+      meta: {
+        title: "タイトル",
+        description: "説明",
+        date: new Date("2023-10-23T00:00:00.000Z"),
+        published: true,
+      },
+    });
+  });
+});

--- a/packages/frontend/src/features/context/fetch.test.ts
+++ b/packages/frontend/src/features/context/fetch.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get_post, get_posts_date_sorted, get_published_posts } from "./fetch";
+
+const query = vi.fn();
+
+vi.mock("@/libs/graphql", () => ({
+  client: { query: (...args: unknown[]) => query(...args) },
+}));
+vi.mock("./getContexts.graphql", () => ({ default: "GetContexts" }));
+vi.mock("./getContextBySlug.graphql", () => ({ default: "GetContextBySlug" }));
+
+const context = (overrides: Record<string, unknown> = {}) => ({
+  slug: "voice",
+  title: "声帯",
+  emoji: "🗣️",
+  content: "本文",
+  published: true,
+  createdAt: "2024-01-12T09:02:49.671Z",
+  updatedAt: "2024-01-12T09:02:49.671Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.stubEnv("ALLOW_EMPTY_CONTENT", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  query.mockReset();
+});
+
+describe("get_published_posts", () => {
+  // commit 8ef7e8e まで published フィルタの欠落で未公開記事が公開されていた。
+  // その回帰を検知するためのテスト。
+  it("published: false の記事を除外する", async () => {
+    query.mockResolvedValue({
+      data: {
+        contexts: [
+          context({ slug: "public" }),
+          context({ slug: "draft", published: false }),
+        ],
+      },
+    });
+
+    const posts = await get_published_posts();
+
+    expect(posts.map((p) => p.slug)).toEqual(["public"]);
+  });
+
+  it("フェッチ失敗時はビルドを落とす (throw)", async () => {
+    query.mockResolvedValue({ data: undefined, error: { message: "boom" } });
+
+    await expect(get_published_posts()).rejects.toThrow(
+      "Failed to fetch contexts: boom",
+    );
+  });
+
+  it("ALLOW_EMPTY_CONTENT=1 のときは空配列で継続する", async () => {
+    vi.stubEnv("ALLOW_EMPTY_CONTENT", "1");
+    query.mockResolvedValue({ data: undefined, error: { message: "boom" } });
+
+    await expect(get_published_posts()).resolves.toEqual([]);
+  });
+});
+
+describe("get_posts_date_sorted", () => {
+  it("新しい記事から順に並べる", async () => {
+    query.mockResolvedValue({
+      data: {
+        contexts: [
+          context({ slug: "old", createdAt: "2024-01-08T11:25:53.246Z" }),
+          context({ slug: "new", createdAt: "2024-01-12T09:02:49.671Z" }),
+        ],
+      },
+    });
+
+    const posts = await get_posts_date_sorted();
+
+    expect(posts.map((p) => p.slug)).toEqual(["new", "old"]);
+  });
+});
+
+describe("get_post", () => {
+  it("存在しない slug は null を返す", async () => {
+    query.mockResolvedValue({ data: { context: null } });
+
+    await expect(get_post("missing")).resolves.toBeNull();
+  });
+
+  it("記事をメタデータ付きで返す", async () => {
+    query.mockResolvedValue({ data: { context: context() } });
+
+    const post = await get_post("voice");
+
+    expect(post).toMatchObject({
+      slug: "voice",
+      content: "本文",
+      meta: {
+        title: "声帯",
+        emoji: "🗣️",
+        date: new Date("2024-01-12T09:02:49.671Z"),
+        published: true,
+      },
+    });
+  });
+});

--- a/packages/frontend/vitest.config.mts
+++ b/packages/frontend/vitest.config.mts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    include: ["src/**/*.test.ts"],
-  },
-});


### PR DESCRIPTION
## 概要

#28 の優先順 1「frontend の fetch 層」のテスト追加。新規依存なし(既存の vitest のみ)。

- **published フィルタ**: 未公開記事が公開される回帰(commit 8ef7e8e まで潜伏していたバグと同型)を blog / context 両方で検知
- フェッチ失敗時に throw してビルドを落とすこと、`ALLOW_EMPTY_CONTENT=1` では空配列で継続することの分岐
- `get_posts_date_sorted` の新しい順ソート
- 画像 URL が `BACKEND_URL` + sha256 キーから組み立てられること(imageKey 契約)
- `get_post` の null / メタデータ返却

## 補足

- `vitest.config` に `@/` alias を追加(fetch 層が `@/libs/*` を import するため)。`import.meta` を使う都合で `.mts` に変更し、CJS ロード警告を回避
- `.graphql` document import と urql client は vi.mock で差し替え

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK