### PR TITLE
test(graphql): cover resolvers with vitest-pool-workers + real D1

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "src/lib.ts",
   "scripts": {
-    "typecheck": "tsc --project . --noEmit"
+    "typecheck": "tsc --project . --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@asa1984.dev/drizzle": "workspace:*",
@@ -15,10 +16,12 @@
   },
   "devDependencies": {
     "@asa1984.dev/tsconfig": "workspace:*",
+    "@cloudflare/vitest-pool-workers": "0.21.3",
     "@cloudflare/workers-types": "catalog:",
     "better-sqlite3": "catalog:",
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/graphql/src/graphql/resolvers.test.ts
+++ b/packages/graphql/src/graphql/resolvers.test.ts
@@ -1,0 +1,252 @@
+import { env } from "cloudflare:test";
+import { graphql } from "graphql";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GraphQLContext, Revalidater } from "../types";
+import { builder } from "./index";
+
+const schema = builder.toSchema();
+
+// Storage is shared across tests in this file, so start each test from an
+// empty database instead of relying on isolation.
+beforeEach(async () => {
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM blogs"),
+    env.DB.prepare("DELETE FROM contexts"),
+  ]);
+});
+
+// Records revalidation calls so tests can assert the cache invalidation
+// contract without any HTTP transport.
+const make_context = (): { context: GraphQLContext; revalidated: string[] } => {
+  const revalidated: string[] = [];
+  const revalidater: Revalidater = {
+    revalidateAllBlog: async () => {
+      revalidated.push("allBlog");
+    },
+    revalidateBlog: async (slug) => {
+      revalidated.push(`blog:${slug}`);
+    },
+    revalidateAllContext: async () => {
+      revalidated.push("allContext");
+    },
+    revalidateContext: async (slug) => {
+      revalidated.push(`context:${slug}`);
+    },
+  };
+  return { context: { DB: env.DB, revalidater }, revalidated };
+};
+
+const exec = async (
+  source: string,
+  contextValue: GraphQLContext,
+  variableValues?: Record<string, unknown>,
+) => {
+  const result = await graphql({
+    schema,
+    source,
+    contextValue,
+    variableValues,
+  });
+  if (result.errors) throw result.errors[0];
+  // Loosely typed on purpose: assertions navigate the response shape.
+  return result.data as Record<string, any>;
+};
+
+const UPSERT_BLOG = `
+  mutation ($input: UpsertBlogInput!) {
+    upsertBlog(input: $input) {
+      slug title image description content published createdAt updatedAt
+    }
+  }
+`;
+
+const blog_input = (overrides: Record<string, unknown> = {}) => ({
+  slug: "first",
+  title: "タイトル",
+  image: "cover.webp",
+  description: "説明",
+  content: "本文",
+  published: true,
+  ...overrides,
+});
+
+describe("blog resolvers", () => {
+  it("upsertBlog は新規記事を作成し createdAt を自動採番する", async () => {
+    const { context } = make_context();
+
+    const data = await exec(UPSERT_BLOG, context, { input: blog_input() });
+
+    expect(data.upsertBlog).toMatchObject(blog_input());
+    expect(Date.parse(data.upsertBlog["createdAt"])).not.toBeNaN();
+  });
+
+  it("upsertBlog は createdAt 指定時にその値を保存する (insert / update 両方)", async () => {
+    const { context } = make_context();
+    const date = "2023-10-23T00:00:00.000Z";
+
+    const inserted = await exec(UPSERT_BLOG, context, {
+      input: blog_input({ createdAt: date }),
+    });
+    expect(inserted.upsertBlog["createdAt"]).toBe(date);
+
+    const rewritten = "2022-11-15T15:00:00.000Z";
+    const updated = await exec(UPSERT_BLOG, context, {
+      input: blog_input({ createdAt: rewritten }),
+    });
+    expect(updated.upsertBlog["createdAt"]).toBe(rewritten);
+  });
+
+  it("upsertBlog は既存記事を更新し createdAt を保持する", async () => {
+    const { context } = make_context();
+
+    const inserted = await exec(UPSERT_BLOG, context, {
+      input: blog_input({ createdAt: "2023-10-23T00:00:00.000Z" }),
+    });
+
+    const updated = await exec(UPSERT_BLOG, context, {
+      input: blog_input({ title: "改題", published: false }),
+    });
+
+    expect(updated.upsertBlog).toMatchObject({
+      title: "改題",
+      published: false,
+      createdAt: inserted.upsertBlog["createdAt"],
+    });
+
+    const listed = await exec("{ blogs { slug } }", context);
+    expect(listed.blogs).toHaveLength(1);
+  });
+
+  it("blog は slug で取得でき、未知の slug は null を返す", async () => {
+    const { context } = make_context();
+    await exec(UPSERT_BLOG, context, { input: blog_input() });
+
+    const found = await exec(
+      "query ($slug: String) { blog(slug: $slug) { slug title } }",
+      context,
+      { slug: "first" },
+    );
+    expect(found.blog).toMatchObject({ slug: "first", title: "タイトル" });
+
+    const missing = await exec(
+      "query ($slug: String) { blog(slug: $slug) { slug } }",
+      context,
+      { slug: "nope" },
+    );
+    expect(missing.blog).toBeNull();
+  });
+
+  it("blogs は未公開記事も含めて返す (published フィルタは frontend 責務)", async () => {
+    const { context } = make_context();
+    await exec(UPSERT_BLOG, context, { input: blog_input() });
+    await exec(UPSERT_BLOG, context, {
+      input: blog_input({ slug: "draft", published: false }),
+    });
+
+    const data = await exec("{ blogs { slug published } }", context);
+    expect(data.blogs).toHaveLength(2);
+  });
+
+  it("deleteBlog は削除で true、対象なしで false を返す", async () => {
+    const { context } = make_context();
+    await exec(UPSERT_BLOG, context, { input: blog_input() });
+
+    const deleted = await exec(
+      'mutation { deleteBlog(slug: "first") }',
+      context,
+    );
+    expect(deleted.deleteBlog).toBe(true);
+
+    const listed = await exec("{ blogs { slug } }", context);
+    expect(listed.blogs).toHaveLength(0);
+
+    const again = await exec('mutation { deleteBlog(slug: "first") }', context);
+    expect(again.deleteBlog).toBe(false);
+  });
+
+  it("ミューテーションは frontend キャッシュを revalidate する", async () => {
+    const { context, revalidated } = make_context();
+
+    await exec(UPSERT_BLOG, context, { input: blog_input() });
+    expect(revalidated).toEqual(["allBlog"]);
+
+    revalidated.length = 0;
+    await exec(UPSERT_BLOG, context, { input: blog_input({ title: "改" }) });
+    expect(revalidated).toEqual(["blog:first", "allBlog"]);
+
+    revalidated.length = 0;
+    await exec('mutation { deleteBlog(slug: "first") }', context);
+    expect(revalidated).toEqual(["blog:first", "allBlog"]);
+  });
+});
+
+const UPSERT_CONTEXT = `
+  mutation ($input: UpsertContextInput!) {
+    upsertContext(input: $input) {
+      slug title emoji content published createdAt updatedAt
+    }
+  }
+`;
+
+const context_input = (overrides: Record<string, unknown> = {}) => ({
+  slug: "voice",
+  title: "声帯",
+  emoji: "🗣️",
+  content: "本文",
+  published: true,
+  ...overrides,
+});
+
+describe("context resolvers", () => {
+  it("upsertContext は insert / update とも createdAt 指定を反映する", async () => {
+    const { context } = make_context();
+    const date = "2024-01-12T09:02:49.671Z";
+
+    const inserted = await exec(UPSERT_CONTEXT, context, {
+      input: context_input({ createdAt: date }),
+    });
+    expect(inserted.upsertContext).toMatchObject({
+      ...context_input(),
+      createdAt: date,
+    });
+
+    const updated = await exec(UPSERT_CONTEXT, context, {
+      input: context_input({ title: "改題" }),
+    });
+    expect(updated.upsertContext).toMatchObject({
+      title: "改題",
+      createdAt: date,
+    });
+  });
+
+  it("context / contexts クエリと deleteContext が動作する", async () => {
+    const { context, revalidated } = make_context();
+    await exec(UPSERT_CONTEXT, context, { input: context_input() });
+    await exec(UPSERT_CONTEXT, context, {
+      input: context_input({ slug: "draft", published: false }),
+    });
+
+    const listed = await exec("{ contexts { slug published } }", context);
+    expect(listed.contexts).toHaveLength(2);
+
+    const found = await exec(
+      'query { context(slug: "voice") { slug emoji } }',
+      context,
+    );
+    expect(found.context).toMatchObject({ slug: "voice", emoji: "🗣️" });
+
+    revalidated.length = 0;
+    const deleted = await exec(
+      'mutation { deleteContext(slug: "voice") }',
+      context,
+    );
+    expect(deleted.deleteContext).toBe(true);
+    expect(revalidated).toEqual(["context:voice", "allContext"]);
+
+    const missing = await exec(
+      'query { context(slug: "voice") { slug } }',
+      context,
+    );
+    expect(missing.context).toBeNull();
+  });
+});

--- a/packages/graphql/test/apply-migrations.ts
+++ b/packages/graphql/test/apply-migrations.ts
@@ -1,0 +1,3 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/packages/graphql/test/env.d.ts
+++ b/packages/graphql/test/env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+declare namespace Cloudflare {
+  interface Env {
+    DB: D1Database;
+    TEST_MIGRATIONS: import("cloudflare:test").D1Migration[];
+  }
+}

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -6,6 +6,6 @@
     "lib": ["esnext"],
     "outDir": "dist"
   },
-  "include": ["src", "bin"],
+  "include": ["src", "bin", "test", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/graphql/vitest.config.ts
+++ b/packages/graphql/vitest.config.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import {
+  cloudflareTest,
+  readD1Migrations,
+} from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig(async () => {
+  // The drizzle package owns the migrations; replaying them here keeps the
+  // test database schema identical to production D1.
+  const migrations = await readD1Migrations(
+    path.resolve(import.meta.dirname, "../drizzle/migrations"),
+  );
+  return {
+    plugins: [
+      cloudflareTest({
+        miniflare: {
+          compatibilityDate: "2026-08-01",
+          d1Databases: ["DB"],
+          bindings: { TEST_MIGRATIONS: migrations },
+        },
+      }),
+    ],
+    test: {
+      include: ["src/**/*.test.ts"],
+      setupFiles: ["./test/apply-migrations.ts"],
+    },
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@asa1984.dev/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@cloudflare/vitest-pool-workers':
+        specifier: 0.21.3
+        version: 0.21.3(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.16.9)(tsx@4.23.12)(yaml@2.9.0)))
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260812.1
@@ -393,6 +396,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.16.9)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tsconfig: {}
 
@@ -695,8 +701,21 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vitest-pool-workers@0.21.3':
+    resolution: {integrity: sha512-jCoGRQ6FlsP5adp1GJISvITOGdTHTpsWOq3KkSGIfeDY/5RKjTUagDwaXjpqBXY5gAk6id/QbgnGuCTAg6lSTQ==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
   '@cloudflare/workerd-darwin-64@1.20260804.1':
     resolution: {integrity: sha512-191/PPEFicRK2wK69eXzSjnLgHL79k7zR2VUpyIr8rhFgGns1b5bTHgnBuUrgU2LPbEtwbE5eL2hJ0uhLAFEow==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -707,8 +726,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260804.1':
     resolution: {integrity: sha512-KBCjxBIlN2jucfQGaTK4EgmPsWzQgYR/zYhPfi3mkWwdoTyG1dgrt2aizKps/SYse85ci/SOxojKk0/K7vstPw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -719,8 +750,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260804.1':
     resolution: {integrity: sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2809,6 +2852,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -3958,6 +4004,10 @@ packages:
     resolution: {integrity: sha512-J0QBHEj+d75TyFE9VhH+2dXgvdYt/pfyDlm+9IiYUFocQvqYy9iuW1DIqNawh1N7Kr6iMrDzVkgDSdt6pA75uA==}
     engines: {node: '>=22.0.0'}
 
+  miniflare@5.20260811.1-alpha:
+    resolution: {integrity: sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -4886,12 +4936,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260811.1:
+    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.121.0:
     resolution: {integrity: sha512-dcARWk6CyaD0vJBSLjJn4K2yo+mYko73hzryq+t/9DXnyAq877RWIMl7uOMcDKs5dDXdoickNhZTKxBYT9XKsA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260804.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.123.0:
+    resolution: {integrity: sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260811.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -5616,19 +5681,55 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260804.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260811.1
+
+  '@cloudflare/vitest-pool-workers@0.21.3(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.16.9)(tsx@4.23.12)(yaml@2.9.0)))':
+    dependencies:
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      vitest: 4.1.10(@types/node@22.19.19)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.16.9)(tsx@4.23.12)(yaml@2.9.0))
+      wrangler: 4.123.0(@cloudflare/workers-types@5.20260812.1)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20260804.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260804.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260804.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260804.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260804.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
     optional: true
 
   '@cloudflare/workers-types@5.20260812.1': {}
@@ -7455,6 +7556,8 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cjs-module-lexer@1.2.3: {}
+
   client-only@0.0.1: {}
 
   cliui@5.0.0:
@@ -8908,6 +9011,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@5.20260811.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260811.1
+      ws: 8.21.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.9
@@ -9931,6 +10046,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260804.1
       '@cloudflare/workerd-windows-64': 1.20260804.1
 
+  workerd@1.20260811.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
+      '@cloudflare/workerd-linux-64': 1.20260811.1
+      '@cloudflare/workerd-linux-arm64': 1.20260811.1
+      '@cloudflare/workerd-windows-64': 1.20260811.1
+
   wrangler@4.121.0(@cloudflare/workers-types@5.20260812.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -9941,6 +10064,23 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260804.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 5.20260812.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.123.0(@cloudflare/workers-types@5.20260812.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260811.1
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260812.1
       fsevents: 2.3.3


### PR DESCRIPTION
## 概要

#28 の優先順 2「GraphQL リゾルバ(D1 込み)」。@cloudflare/vitest-pool-workers 0.21.3 を導入し、workerd + miniflare の実 D1 でリゾルバを統合テストする(9 件)。

## 構成

- `vitest.config.ts`: vitest 4 世代の `cloudflareTest` plugin API(旧 `defineWorkersConfig` は 0.21 で廃止)。drizzle の migrations を `readD1Migrations` で読み、setup で `applyD1Migrations` — 本番とスキーマが常に一致
- revalidater は記録用モックで、キャッシュ無効化の呼び出し契約も検証
- ストレージがテスト間で共有されるため、beforeEach で全行削除して独立性を保証

## カバレッジ

- upsertBlog/upsertContext: insert・update、**createdAt 指定の反映と保持**(#46 の git 正本契約)
- blog/blogs/context/contexts クエリ(未知 slug は null、未公開記事も返す = published フィルタは frontend 責務であることの明文化)
- deleteBlog/deleteContext の true/false と削除の実効
- revalidate 契約: insert→all のみ、update/delete→個別+all

## 検証

- 全 workspace テスト 122 件緑(cli 89 / graphql 9 / frontend 24)、typecheck / lint / format 緑
- CI は `pnpm -r run test` なので test スクリプト追加だけで自動的に乗る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK