### PR TITLE
test(frontend): cover remark_linkcard and remark_zenn_message

### DIFF
--- a/packages/frontend/src/features/markdown/lib/remark_linkcard.test.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_linkcard.test.ts
@@ -1,0 +1,67 @@
+import type { Root } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { remark_linkcard } from "./remark_linkcard";
+
+const parse = (markdown: string): Root => {
+  const processor = unified().use(remarkParse).use(remarkGfm);
+  const tree = processor.parse(markdown);
+  remark_linkcard()(tree, undefined as never, undefined as never);
+  return tree as Root;
+};
+
+type LinkcardNode = {
+  type: "linkcard";
+  data: { hProperties: { url: string } };
+};
+
+const linkcards = (root: Root): LinkcardNode[] =>
+  root.children.filter(
+    (node): node is never => node.type === ("linkcard" as never),
+  ) as unknown as LinkcardNode[];
+
+describe("remark_linkcard", () => {
+  it("URL と同一テキストの単独リンク段落を linkcard に変換する", () => {
+    const tree = parse("<https://example.com/article>");
+
+    const cards = linkcards(tree);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.data.hProperties.url).toBe("https://example.com/article");
+  });
+
+  it("@card テキストのリンクも linkcard に変換する", () => {
+    const tree = parse("[@card](https://example.com/article)");
+
+    const cards = linkcards(tree);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.data.hProperties.url).toBe("https://example.com/article");
+  });
+
+  it("通常のインラインリンクは変換しない", () => {
+    const tree = parse("これは[リンク](https://example.com)を含む文です。");
+
+    expect(linkcards(tree)).toHaveLength(0);
+    expect(tree.children[0]?.type).toBe("paragraph");
+  });
+
+  it("リンクの前後にテキストがある段落は変換しない", () => {
+    const tree = parse("前置き <https://example.com> 後書き");
+
+    expect(linkcards(tree)).toHaveLength(0);
+  });
+
+  it("複数の linkcard 段落をそれぞれ変換する", () => {
+    const tree = parse(
+      "<https://example.com/a>\n\n本文の段落。\n\n<https://example.com/b>",
+    );
+
+    const cards = linkcards(tree);
+    expect(cards.map((c) => c.data.hProperties.url)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+    expect(tree.children).toHaveLength(3);
+  });
+});

--- a/packages/frontend/src/features/markdown/lib/remark_zenn_message.test.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_zenn_message.test.ts
@@ -1,0 +1,69 @@
+import type { Root, Text } from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { remark_zenn_message } from "./remark_zenn_message";
+
+const parse = (markdown: string): Root => {
+  const processor = unified().use(remarkParse).use(remarkGfm);
+  const tree = processor.parse(markdown);
+  remark_zenn_message()(tree, undefined as never, undefined as never);
+  return tree as Root;
+};
+
+type MessageNode = {
+  type: "message";
+  children: { type: string; value?: string }[];
+};
+
+const messages = (root: Root): MessageNode[] =>
+  root.children.filter(
+    (node): node is never => node.type === ("message" as never),
+  ) as unknown as MessageNode[];
+
+describe("remark_zenn_message", () => {
+  it(":::message ブロックを message ノードに変換する", () => {
+    const tree = parse(":::message\n注意書きです\n:::");
+
+    const found = messages(tree);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.children).toMatchObject([
+      { type: "text", value: "注意書きです" },
+    ]);
+  });
+
+  it("強調などのインライン要素を保持する", () => {
+    const tree = parse(":::message\n注意: **重要** です\n:::");
+
+    const found = messages(tree);
+    expect(found).toHaveLength(1);
+    const types = found[0]?.children.map((c) => c.type);
+    expect(types).toEqual(["text", "strong", "text"]);
+    expect((found[0]?.children[0] as Text).value).toBe("注意: ");
+  });
+
+  it("マーカーだけの行は捨てて中身だけ残す (複数行)", () => {
+    const tree = parse(":::message\n1行目\n2行目\n:::");
+
+    const found = messages(tree);
+    expect(found).toHaveLength(1);
+    const texts = found[0]?.children
+      .filter((c): c is Text & { type: "text" } => c.type === "text")
+      .map((c) => c.value);
+    expect(texts?.join("")).toBe("1行目\n2行目");
+  });
+
+  it("通常の段落は変換しない", () => {
+    const tree = parse("ただの段落です。");
+
+    expect(messages(tree)).toHaveLength(0);
+    expect(tree.children[0]?.type).toBe("paragraph");
+  });
+
+  it("閉じマーカーのない段落は変換しない", () => {
+    const tree = parse(":::message\n閉じ忘れ");
+
+    expect(messages(tree)).toHaveLength(0);
+  });
+});

--- a/packages/frontend/src/features/markdown/lib/remark_zenn_message.test.ts
+++ b/packages/frontend/src/features/markdown/lib/remark_zenn_message.test.ts
@@ -40,7 +40,10 @@ describe("remark_zenn_message", () => {
     expect(found).toHaveLength(1);
     const types = found[0]?.children.map((c) => c.type);
     expect(types).toEqual(["text", "strong", "text"]);
-    expect((found[0]?.children[0] as Text).value).toBe("注意: ");
+    expect(found[0]?.children[0]).toMatchObject({
+      type: "text",
+      value: "注意: ",
+    });
   });
 
   it("マーカーだけの行は捨てて中身だけ残す (複数行)", () => {


### PR DESCRIPTION
## 概要

#28 の優先順 3「markdown 変換系」。自作 remark プラグインのうち未テストだった remark_linkcard / remark_zenn_message を、既存の remark_inline_footnote テストと同じ形式でカバー(10 件追加、frontend 計 34 件)。新規依存なし。

- **remark_linkcard**: URL と同一テキストの単独リンク段落・`[@card](url)` の変換、インラインリンクや前後テキストあり段落の非変換、複数変換
- **remark_zenn_message**: `:::message` ブロックの変換とマーカー除去、`**強調**` などインライン要素の保持、複数行、通常段落・閉じマーカーなしの非変換

## 検証

- frontend テスト 34 件 / typecheck / lint / format 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TVQ5214yCm2ccE7dksDnK