### PR TITLE
fix: plaintext コードブロックの文字色が背景に同化する問題を修正

### DIFF
--- a/packages/frontend/src/features/markdown/article.module.scss
+++ b/packages/frontend/src/features/markdown/article.module.scss
@@ -148,6 +148,10 @@
       overflow-x: auto;
       border-radius: var(--radii-lg);
       background-color: #222436;
+      // Moonlight II の前景色。shiki は plaintext フェンスにトークン色の
+      // inline style を付けないため、デフォルトの文字色をテーマ前景に
+      // 合わせておかないと暗背景に同化する。
+      color: #c8d3f5;
       code {
         counter-reset: line;
       }


### PR DESCRIPTION
## 概要

`/blog/first` の最初のコードブロック(```plaintext フェンスの処理図)の文字が背景 `#222436` に同化していた。

shiki は plaintext にトークン色の inline style を出力しないため、文字色が記事本文の色(濃色)のまま暗背景に載っていた(#76 で背景スタイルが正しく適用されるようになり顕在化)。`pre` のデフォルト文字色を Moonlight II の前景 `#c8d3f5` に設定。ハイライトされる言語は従来通り inline style が優先される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRef2qBhH9YpY8QJ3AZXdz