### PR TITLE
fix: pin content fetches to a commit SHA (stale GitHub ref resolution)

### DIFF
--- a/packages/frontend/src/features/content/github.ts
+++ b/packages/frontend/src/features/content/github.ts
@@ -9,16 +9,20 @@ const API_ROOT = `https://api.github.com/repos/${CONTENT_REPO}`;
 
 // Every fetch below is cached in Next's data cache under this tag.
 // Nothing invalidates the tag right now: the webhook receiver was removed
-// (instant reflection is temporarily out of scope) and the interval below
-// is the only freshness mechanism. The content repo's GitHub webhook is
-// still configured and its deliveries just 404; the tag stays so a future
-// receiver can revalidate it again.
+// (instant reflection is temporarily out of scope) and the ref-resolution
+// interval below is the only freshness mechanism. The content repo's
+// GitHub webhook is still configured and its deliveries just 404; the tag
+// stays so a future receiver can revalidate it again.
 export const CONTENT_CACHE_TAG = "content";
 
-// Sole freshness mechanism: the data cache serves stale entries and
-// refreshes them in the background after this interval, so a content push
-// is visible within this window at the latest.
-const CONTENT_REVALIDATE_SECONDS = 300;
+// How often the branch ref is re-resolved, and therefore the ceiling on
+// how long a content push can take to become visible.
+const REF_RESOLVE_SECONDS = 300;
+
+// Tree/file responses are addressed by commit SHA, which is immutable, so
+// they can live long; the interval only bounds junk accumulating in the
+// cache, not correctness.
+const IMMUTABLE_REVALIDATE_SECONDS = 86_400;
 
 const github_headers = (accept: string) => ({
   Accept: accept,
@@ -27,15 +31,43 @@ const github_headers = (accept: string) => ({
   "User-Agent": "asa1984.dev",
 });
 
-const cache_options: { next: { revalidate: number; tags: string[] } } = {
-  next: { revalidate: CONTENT_REVALIDATE_SECONDS, tags: [CONTENT_CACHE_TAG] },
-};
+const cache_options = (revalidate: number): { next: { revalidate: number; tags: string[] } } => ({
+  next: { revalidate, tags: [CONTENT_CACHE_TAG] },
+});
 
 const encode_path = (path: string) =>
   path
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
+
+/**
+ * The commit SHA the content ref currently points to.
+ *
+ * Everything else is fetched by this SHA instead of the branch name: the
+ * GitHub API has been observed to pin a branch-name URL polled from the
+ * same token to a stale answer for hours (2026-08-17: `git/trees/main`
+ * kept resolving to the pre-push commit all day). SHA-addressed responses
+ * are immutable, so only this one lookup needs to be stale-proof — the
+ * `bust` parameter rotates the URL (and thereby every cache key on the
+ * way to GitHub) each interval, so no cache can pin it.
+ */
+async function resolve_content_sha(): Promise<string> {
+  // CI smoke builds run without a GitHub token and expect an empty site.
+  if (process.env["ALLOW_EMPTY_CONTENT"] === "1") {
+    return CONTENT_REF;
+  }
+  const bucket = Math.floor(Date.now() / (REF_RESOLVE_SECONDS * 1000));
+  const res = await fetch(`${API_ROOT}/commits/${CONTENT_REF}?bust=${String(bucket)}`, {
+    headers: github_headers("application/vnd.github+json"),
+    ...cache_options(REF_RESOLVE_SECONDS),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to resolve content ref: ${String(res.status)}`);
+  }
+  const data = (await res.json()) as { sha: string };
+  return data.sha;
+}
 
 /**
  * All blob paths in the content repository (e.g. "blog/first/post.md").
@@ -49,9 +81,10 @@ export async function list_content_paths(): Promise<string[]> {
     return [];
   }
 
-  const res = await fetch(`${API_ROOT}/git/trees/${CONTENT_REF}?recursive=1`, {
+  const sha = await resolve_content_sha();
+  const res = await fetch(`${API_ROOT}/git/trees/${sha}?recursive=1`, {
     headers: github_headers("application/vnd.github+json"),
-    ...cache_options,
+    ...cache_options(IMMUTABLE_REVALIDATE_SECONDS),
   });
   if (!res.ok) {
     throw new Error(`Failed to list content tree: ${String(res.status)}`);
@@ -68,9 +101,10 @@ export async function list_content_paths(): Promise<string[]> {
 }
 
 async function fetch_content_file(path: string): Promise<Response> {
-  return fetch(`${API_ROOT}/contents/${encode_path(path)}?ref=${CONTENT_REF}`, {
+  const sha = await resolve_content_sha();
+  return fetch(`${API_ROOT}/contents/${encode_path(path)}?ref=${sha}`, {
     headers: github_headers("application/vnd.github.raw+json"),
-    ...cache_options,
+    ...cache_options(IMMUTABLE_REVALIDATE_SECONDS),
   });
 }
 


### PR DESCRIPTION
## 障害の内容

2026-08-17 10:49 の content push (`733ef97` fp-matsuri-2026 追加) 後、本番サイトから記事が消え 404 になった。

調査の結果、**GitHub API が worker のトークンに対して `git/trees/main` を push 前のコミット `14d61de` に解決し続けていた**ことが原因と特定した。

- KV 内のキャッシュエントリは 5 分ごとに正しく再取得・更新されていた (SWR は正常)
- 各レスポンスの `date` ヘッダは毎回新しいのに tree sha だけが `14d61de` に固定 (= HTTP キャッシュ再生ではなく GitHub 側の stale な ref 解決)
- 別トークン (gh CLI) では終始新鮮なデータが返っており、固定は URL + トークン単位
- worker が 5 分間隔で同一 URL をポーリングし続けることが stale 状態を延命していたとみられる
- KV エントリの purge では回復せず (同じ stale データが再充填される)

## 修正

**mutable な URL を 1 箇所に集約し、それ以外を immutable アドレスにする。**

1. `resolve_content_sha()`: `commits/main` で branch → SHA を解決。URL に 5 分バケットの `bust` パラメータを付与し、経路上のどのキャッシュにも固定されないようにする (GitHub は未知のクエリパラメータを無視する)
2. tree (`git/trees/<sha>`) とファイル (`contents/<path>?ref=<sha>`) は解決した SHA で取得。SHA アドレスは不変なので stale な応答が原理的に存在せず、1 日キャッシュしても安全

反映遅延の上限は従来どおり ref 解決の 5 分。

KV への追加書き込みは ref 解決エントリが最大 288 件/日 (数百バイト each)。tree / ファイルは SHA が変わったときだけ新規エントリになる。

## 検証

- typecheck / test 45 件 / lint / fmt 通過
- smoke build (ALLOW_EMPTY_CONTENT=1) 通過
- ローカル workerd + 実トークンで E2E 確認: `/blog` 一覧に fp-matsuri-2026 が表示され、記事は 200。KV には `commits/main?bust=<bucket>` / `git/trees/733ef97…` / `contents/…?ref=733ef97…` の形でエントリが作られることを確認

## 補足

- 本番は現在も GitHub 側の stale 固定が続いているため、この PR のデプロイ (URL が変わる) で即座に回復する見込み。`CONTENT_GITHUB_TOKEN` のローテーションでも回復する
- 別件の慢性課題として、OpenNext 公式は KV incremental cache を「結果整合なので非推奨」としており (https://opennext.js.org/cloudflare/caching)、R2 への移行は将来の検討事項

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqcAr1JdANXrRNQHwSN7zo