### PR TITLE
fix: point the dev env at a recreated KV namespace

### DIFF
--- a/packages/frontend/wrangler.jsonc
+++ b/packages/frontend/wrangler.jsonc
@@ -49,14 +49,12 @@
     },
     "dev": {
       "name": "asa1984-web-dev",
-      // Custom domain so Cloudflare Access can sit in front of it
-      // (scripts/setup-dev-access.sh).
       "routes": [{ "pattern": "dev.asa1984.dev", "custom_domain": true }],
       "vars": { "FRONTEND_URL": "https://dev.asa1984.dev" },
       "kv_namespaces": [
         {
           "binding": "NEXT_INC_CACHE_KV",
-          "id": "769aa223fd044c86aa2558c0d0568adf",
+          "id": "a34fd8a8f864488b99fedb279414dbd8",
         },
       ],
       "services": [


### PR DESCRIPTION
## 背景

dev 用 KV namespace (`769aa223…`) が誤削除され、PR #81 マージ時の Deploy (dev) が失敗した。

## 変更

- `asa1984-web-dev-opennext-cache` (`a34fd8a8f864488b99fedb279414dbd8`) を新規作成済み (本番の `asa1984-web-opennext-cache` と同じ命名規則)
- wrangler.jsonc の dev env をその ID に更新

キャッシュ namespace なので中身は空で問題なく、アクセスに応じて再構築される。
リポジトリ内に旧 ID への他の参照はないことを確認済み。

マージ後、失敗した Deploy (dev) を re-run するか、この PR のマージで走る Deploy (dev) で dev 環境が復旧する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqcAr1JdANXrRNQHwSN7zo